### PR TITLE
feat: 新API構造対応とUI簡素化 (Issue #103, #109, #129)

### DIFF
--- a/index.html
+++ b/index.html
@@ -910,21 +910,27 @@
         <input type="text" id="regName" class="select" placeholder="山田太郎" required />
       </div>
 
+      <!-- MVP: スタッフコード入力を廃止 (Issue #129) -->
+      <!--
       <div style="margin-bottom:10px">
         <label class="helper" style="display:block;margin-bottom:4px">🔖 スタッフコード</label>
         <input type="text" id="regStaffCode" class="select" placeholder="STAFF001" required />
         <div class="helper small">※ 半角英数字で入力してください</div>
       </div>
+      -->
 
       <div style="margin-bottom:10px">
         <label class="helper" style="display:block;margin-bottom:4px">💼 雇用形態</label>
         <select id="regEmploymentType" class="select" required></select>
       </div>
 
+      <!-- MVP: 役職選択を非表示 (Issue #109) -->
+      <!--
       <div style="margin-bottom:10px">
         <label class="helper" style="display:block;margin-bottom:4px">👔 役職</label>
         <select id="regRole" class="select" required></select>
       </div>
+      -->
 
       <div style="margin-bottom:10px">
         <label class="helper" style="display:block;margin-bottom:4px">📧 メールアドレス（任意）</label>
@@ -942,9 +948,10 @@
     `;
         container.appendChild(registrationCard);
 
-        // 店舗リスト、役職リスト、雇用形態リストを取得して表示
+        // 店舗リスト、雇用形態リストを取得して表示
         loadStoresForRegistration();
-        loadRolesForRegistration();
+        // MVP: 役職選択を非表示 (Issue #109)
+        // loadRolesForRegistration();
         loadEmploymentTypesForRegistration();
 
         // 登録ボタンのイベント
@@ -1026,16 +1033,18 @@
       // ====== スタッフ登録処理 ======
       async function handleStaffRegistration() {
         const storeId = document.getElementById('regStoreSelect').value;
-        const roleId = document.getElementById('regRole').value;
+        // MVP: 役職選択を非表示 (Issue #109) - デフォルト値を使用
+        const roleId = null;
         const name = document.getElementById('regName').value;
-        const staffCode = document.getElementById('regStaffCode').value;
+        // MVP: スタッフコード入力を廃止 (Issue #129) - 自動生成
+        const staffCode = null;
         const employmentType =
           document.getElementById('regEmploymentType').value;
         const email = document.getElementById('regEmail').value;
         const phone = document.getElementById('regPhone').value;
 
         // バリデーション
-        if (!storeId || !roleId || !name || !staffCode || !employmentType) {
+        if (!storeId || !name || !employmentType) {
           alert('必須項目を入力してください');
           return;
         }
@@ -1056,9 +1065,9 @@
             body: JSON.stringify({
               tenant_id: TENANT_ID,
               store_id: parseInt(storeId),
-              role_id: parseInt(roleId),
+              role_id: roleId, // nullを送信（バックエンドでデフォルト値を設定）
               name: name,
-              staff_code: staffCode,
+              staff_code: staffCode, // nullを送信（バックエンドで自動生成）
               employment_type: employmentType,
               email: email || null,
               phone_number: phone || null,


### PR DESCRIPTION
## 変更内容

### 1. 新API構造対応（1日1レコード形式）
- `/api/shifts/preferences/bulk` エンドポイントを使用
- シフト希望データを月単位から日単位に変更
- preference_date形式の変換を追加（ISO形式→YYYY-MM-DD形式）

### 2. パターン入力を廃止 (Issue #103)
- パターン選択UI（早番/遅番など）をコメントアウト
- 時刻入力のみに統一
- mode変数を'time'に固定

### 3. 分入力を許可
- forceHourOnly関数を削除
- formatTime関数で分が00の場合のみ省略表示
- カレンダー表示ラベルの文字つぶれを防止

### 4. スタッフ登録UI簡素化 (Issue #109, #129)
- 役職選択フィールドを非表示
- スタッフコード入力フィールドを非表示
- role_idとstaff_codeをnullで送信（バックエンドでデフォルト値設定）

## テスト
- STG環境で動作確認済み
- シフト希望の登録・読み込みが正常に動作

## 関連Issue
- #103
- #109
- #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)