### PR TITLE
temp: role_idとstaff_codeにダミー値を使用（暫定対応）

### DIFF
--- a/index.html
+++ b/index.html
@@ -1033,11 +1033,13 @@
       // ====== スタッフ登録処理 ======
       async function handleStaffRegistration() {
         const storeId = document.getElementById('regStoreSelect').value;
-        // MVP: 役職選択を非表示 (Issue #109) - デフォルト値を使用
-        const roleId = null;
+        // TODO: バックエンドでnull許可後に削除予定 (Issue #109)
+        // 暫定: デフォルト役職ID=1を使用
+        const roleId = 1;
         const name = document.getElementById('regName').value;
-        // MVP: スタッフコード入力を廃止 (Issue #129) - 自動生成
-        const staffCode = null;
+        // TODO: バックエンドでnull許可後に削除予定 (Issue #129)
+        // 暫定: ダミーのスタッフコードを生成
+        const staffCode = `TEMP_${Date.now()}`;
         const employmentType =
           document.getElementById('regEmploymentType').value;
         const email = document.getElementById('regEmail').value;
@@ -1065,9 +1067,9 @@
             body: JSON.stringify({
               tenant_id: TENANT_ID,
               store_id: parseInt(storeId),
-              role_id: roleId, // nullを送信（バックエンドでデフォルト値を設定）
+              role_id: roleId, // TODO: バックエンド修正後はnullに変更
               name: name,
-              staff_code: staffCode, // nullを送信（バックエンドで自動生成）
+              staff_code: staffCode, // TODO: バックエンド修正後はnullに変更
               employment_type: employmentType,
               email: email || null,
               phone_number: phone || null,


### PR DESCRIPTION
## 変更内容

バックエンドが`role_id`と`staff_code`のnullを許可していないため、暫定的にダミー値を送信するように修正。

### 修正詳細
- **role_id**: `1`（デフォルト役職ID）を送信
- **staff_code**: `TEMP_{タイムスタンプ}`を送信（重複回避）

### コード
```javascript
// TODO: バックエンドでnull許可後に削除予定 (Issue #109)
const roleId = 1;

// TODO: バックエンドでnull許可後に削除予定 (Issue #129)
const staffCode = `TEMP_${Date.now()}`;
```

## 今後の対応
バックエンド側でnull許可の実装後、これらの値をnullに戻す予定。

## 関連Issue
- #109
- #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)