### PR TITLE
fix: 締切表示を動的に生成（deadline_timeを使用）

### DIFF
--- a/index.html
+++ b/index.html
@@ -1367,8 +1367,12 @@
         const month = cur.getMonth() + 1;
         if (isDeadlinePassed(year, month, getEmploymentType())) {
           const prevMonth = month === 1 ? 12 : month - 1;
+          const prevYear = month === 1 ? year - 1 : year;
+          const setting = deadlineSettingsMap.get(getEmploymentType());
+          const deadlineDay = setting?.deadline_day || 10;
+          const deadlineTime = setting?.deadline_time || '12:00';
           alert(
-            `${year}年${month}月のシフト希望入力期限は${month === 1 ? year - 1 : year}年${prevMonth}月10日23:59で終了しました`
+            `${year}年${month}月のシフト希望入力期限は${prevYear}年${prevMonth}月${deadlineDay}日${deadlineTime}で終了しました`
           );
           return;
         }
@@ -1443,13 +1447,19 @@
           if (isPastDeadline) {
             const prevMonth = month === 1 ? 12 : month - 1;
             const prevYear = month === 1 ? year - 1 : year;
-            deadlineInfo.innerHTML = `⚠️ <strong>${year}年${month}月のシフト希望入力期限は${prevYear}年${prevMonth}月10日23:59で終了しました</strong><br>既存の希望は閲覧できますが、編集・新規登録はできません。`;
+            const setting = deadlineSettingsMap.get(getEmploymentType());
+            const deadlineDay = setting?.deadline_day || 10;
+            const deadlineTime = setting?.deadline_time || '12:00';
+            deadlineInfo.innerHTML = `⚠️ <strong>${year}年${month}月のシフト希望入力期限は${prevYear}年${prevMonth}月${deadlineDay}日${deadlineTime}で終了しました</strong><br>既存の希望は閲覧できますが、編集・新規登録はできません。`;
             deadlineInfo.style.display = 'block';
             document.getElementById('submitBtn').disabled = true;
           } else {
             const prevMonth = month === 1 ? 12 : month - 1;
             const prevYear = month === 1 ? year - 1 : year;
-            deadlineInfo.innerHTML = `📅 ${year}年${month}月のシフト希望入力期限: ${prevYear}年${prevMonth}月10日23:59まで`;
+            const setting = deadlineSettingsMap.get(getEmploymentType());
+            const deadlineDay = setting?.deadline_day || 10;
+            const deadlineTime = setting?.deadline_time || '12:00';
+            deadlineInfo.innerHTML = `📅 ${year}年${month}月のシフト希望入力期限: ${prevYear}年${prevMonth}月${deadlineDay}日${deadlineTime}まで`;
             deadlineInfo.style.display = 'block';
             document.getElementById('submitBtn').disabled = false;
           }
@@ -1487,8 +1497,11 @@
         if (isDeadlinePassed(year, month, getEmploymentType())) {
           const prevMonth = month === 1 ? 12 : month - 1;
           const prevYear = month === 1 ? year - 1 : year;
+          const setting = deadlineSettingsMap.get(getEmploymentType());
+          const deadlineDay = setting?.deadline_day || 10;
+          const deadlineTime = setting?.deadline_time || '12:00';
           alert(
-            `${year}年${month}月のシフト希望入力期限は${prevYear}年${prevMonth}月10日23:59で終了しました`
+            `${year}年${month}月のシフト希望入力期限は${prevYear}年${prevMonth}月${deadlineDay}日${deadlineTime}で終了しました`
           );
           return;
         }


### PR DESCRIPTION
## 📋 概要

ハードコードされていた締切表示「10日23:59」を、DBから取得した`deadline_time`を使って動的に生成するように修正。

関連: 
- Backend PR: https://github.com/The-botch/shift-scheduler-ai/pull/166

## 🐛 問題

画面に「2025年12月10日23:59まで」と固定表示されていたが、DBには「12:00」が設定されているため、正しくない表示になっていた。

## ✅ 修正内容

### 修正箇所（4箇所）

1. **日付セルクリック時のアラート**（1371-1375行目）
2. **期限終了メッセージ**（1446-1449行目）
3. **期限表示メッセージ**（1452-1455行目）← 画面表示
4. **送信ボタンクリック時のアラート**（1500-1504行目）

### 変更内容

```javascript
// 変更前
deadlineInfo.innerHTML = `📅 ${year}年${month}月のシフト希望入力期限: ${prevYear}年${prevMonth}月10日23:59まで`;

// 変更後
const setting = deadlineSettingsMap.get(getEmploymentType());
const deadlineDay = setting?.deadline_day || 10;
const deadlineTime = setting?.deadline_time || '12:00';
deadlineInfo.innerHTML = `📅 ${year}年${month}月のシフト希望入力期限: ${prevYear}年${prevMonth}月${deadlineDay}日${deadlineTime}まで`;
```

## 📁 変更ファイル

- `index.html`: 締切表示ロジックを4箇所修正

## 🎯 期待される結果

- 正社員: 「12月10日12:00まで」
- アルバイト: 「12月15日12:00まで」
- 契約社員: 「12月10日12:00まで」
- 派遣社員: 「12月10日12:00まで」

🤖 Generated with [Claude Code](https://claude.com/claude-code)