### PR TITLE
fix: LIFF初期化時のIDトークン取得タイミング問題を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -916,6 +916,7 @@
       // ====== LIFF ======
       async function initLIFF() {
         await liff.init({ liffId: LIFF_ID });
+        await liff.ready; // LIFF初期化完了を待機
 
         // 雇用形態マスタを先に読み込み（役割判定に必要）
         await loadEmploymentTypes();
@@ -937,6 +938,14 @@
         }
         const p = await liff.getProfile();
         const idt = liff.getIDToken();
+
+        // IDトークンが取得できない場合は再ログイン
+        if (!idt) {
+          console.error('IDトークンの取得に失敗しました。再ログインします。');
+          liff.login();
+          return;
+        }
+
         window._login = { name: p.displayName, userId: p.userId, idToken: idt };
         document.getElementById('profileBox').textContent =
           `${p.displayName} さんとしてログイン中`;


### PR DESCRIPTION
## Summary
- 初回友だち追加時に「LINE連携状態の確認に失敗しました」エラーが発生する問題を修正
- `liff.ready` を追加してLIFF初期化完了を待機
- IDトークンがnullの場合に自動で再ログインを実行

## 背景
友だち追加直後にLIFFを開くと、LINE認証のリダイレクト処理中にIDトークンがまだ取得できないケースがあった。

## 変更内容
- `await liff.ready;` を追加（LINE公式推奨の方法）
- `liff.getIDToken()` の結果をnullチェックし、nullなら `liff.login()` を再実行

## Test plan
- [ ] 友だち追加から初回アクセス時にエラーが出ないことを確認
- [ ] 2回目以降のアクセスでも正常動作することを確認
- [ ] 既存のログイン済みユーザーが影響を受けないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)