### PR TITLE
fix: iOS LINEアプリ内でのトークン期限切れ問題を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -915,6 +915,22 @@
 
       // ====== LIFF ======
       async function initLIFF() {
+        // 期限切れトークンをクリア（iOS対策）
+        try {
+          const storageKey = `LIFF_STORE:${LIFF_ID}:decodedIDToken`;
+          const stored = localStorage.getItem(storageKey);
+          if (stored) {
+            const decoded = JSON.parse(stored);
+            if (decoded.exp && decoded.exp * 1000 < Date.now()) {
+              console.log('期限切れトークンをクリアします');
+              localStorage.removeItem(storageKey);
+              localStorage.removeItem(`LIFF_STORE:${LIFF_ID}:accessToken`);
+            }
+          }
+        } catch (e) {
+          console.warn('トークンクリア処理でエラー:', e);
+        }
+
         await liff.init({ liffId: LIFF_ID });
         await liff.ready; // LIFF初期化完了を待機
 
@@ -922,11 +938,19 @@
         await loadEmploymentTypes();
 
         if (!liff.isLoggedIn()) {
-          // ログイン前はシフト入力UI全体を非表示
+          // LINEアプリ内で未ログインの場合は自動ログイン
+          if (liff.isInClient()) {
+            console.log(
+              'LINEアプリ内で未ログイン状態。自動ログインを試みます。'
+            );
+            liff.login();
+            return;
+          }
+
+          // 外部ブラウザの場合はログインボタンを表示
           const cards = document.querySelectorAll('.card');
           cards.forEach((card, index) => {
             if (index > 0) {
-              // 最初のカード（ヘッダー）以外を非表示
               card.style.display = 'none';
             }
           });


### PR DESCRIPTION
## Summary
iOS LINEアプリ内ブラウザでLIFFを開いた際に「LINEログイン前です」と表示される問題を修正

## 問題
- LINEアプリ内ブラウザでトークンが期限切れの場合、`liff.isLoggedIn()` が `false` を返す
- ログインボタンが表示されるが、タップしても正常にログインできないケースがあった

## 修正内容
1. **期限切れトークンのクリア**: `liff.init()` 前にlocalStorageの期限切れトークンを削除
2. **LINEアプリ内の自動ログイン**: `liff.isInClient()` で判定し、自動で `liff.login()` を呼び出し

## 影響範囲
- 既にログイン済みのユーザー: **影響なし**（`isLoggedIn() = true` のため修正部分は実行されない）
- 外部ブラウザ: **従来通り**ログインボタンを表示

## Test plan
- [ ] iOS LINEアプリ内でLIFFを開き、正常にログインされることを確認
- [ ] Android LINEアプリ内でも正常動作することを確認
- [ ] 外部ブラウザ（Safari/Chrome）で従来通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)