### PR TITLE
feat: LINE通知機能を実装（#130, #104）

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,9 +3,16 @@ DATABASE_URL=postgresql://username:password@host:port/database
 
 # LINE Messaging API
 LINE_CHANNEL_ACCESS_TOKEN=your_channel_access_token_here
+LINE_CHANNEL_SECRET=your_channel_secret_here
 
 # サーバー設定
 PORT=3001
 
 # テナントID
 TENANT_ID=3
+
+# LIFF App ID（メッセージ内のURL用）
+LIFF_ID=2008227932-Rq9rJrJn
+
+# 通知有効/無効（テスト時は false にして実際の送信を抑止）
+NOTIFICATION_ENABLED=true

--- a/backend/src/config/line-notification.json
+++ b/backend/src/config/line-notification.json
@@ -1,0 +1,49 @@
+{
+  "groups": {
+    "tenant_3": {
+      "groupId": "C2a7fc3749caa5d026c689f85fe08fd58",
+      "name": "通知テストグループ",
+      "description": "テナント3のスタッフ用LINEグループ（テスト）"
+    }
+  },
+  "reminders": [
+    {
+      "phase": 1,
+      "daysBefore": 7,
+      "type": "anonymous",
+      "targetOnly": null,
+      "message": "【シフト希望入力のお願い】\n\n{targetMonth}月のシフト希望入力がまだの方は\n{deadline}までに入力をお願いします。\n\n入力はこちら: {liffUrl}"
+    },
+    {
+      "phase": 2,
+      "daysBefore": 3,
+      "type": "stats",
+      "targetOnly": "partTime",
+      "message": "【シフト希望提出状況】\n\n{targetMonth}月分: アルバイト {totalCount}名中 {submittedCount}名 提出済み\n未提出: {unsubmittedCount}名\n\n{deadline}までにご提出ください。\n入力はこちら: {liffUrl}"
+    },
+    {
+      "phase": 3,
+      "daysBefore": 1,
+      "type": "named",
+      "targetOnly": "partTime",
+      "message": "【シフト希望 締切前日】\n\n{targetMonth}月分の未提出者（アルバイト）:\n{unsubmittedNames}\n\n明日 {deadline} が締切です。\n入力はこちら: {liffUrl}"
+    },
+    {
+      "phase": 4,
+      "daysBefore": 0,
+      "type": "deadline_passed",
+      "targetOnly": null,
+      "message": "【シフト希望 締切通知】\n\n{targetMonth}月分のシフト希望締切を過ぎました。\n\n未提出の方はオーナーの指示に従ってください。"
+    }
+  ],
+  "approvalMessages": {
+    "firstPlanApproved": "【{targetMonth}月シフト希望入力開始】\n\n第1案が承認されました。\nシフト希望の入力が可能になりました。\n\n締切: {deadline}\n入力はこちら: {liffUrl}",
+    "secondPlanApproved": "【シフト確定のお知らせ】\n\n{targetMonth}月のシフトが確定しました。"
+  },
+  "cronSchedule": "0 9 * * *",
+  "settings": {
+    "deadlineDay": 10,
+    "timezone": "Asia/Tokyo",
+    "enabled": true
+  }
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,7 +1,13 @@
 import express from 'express';
 import dotenv from 'dotenv';
 import cron from 'node-cron';
-import { sendShiftReminders } from './services/reminderService.js';
+import {
+  sendAutoReminder,
+  sendShiftReminders,
+} from './services/reminderService.js';
+import webhookRouter from './routes/webhook.js';
+import notificationRouter from './routes/notification.js';
+import { getNotificationConfig } from './services/lineService.js';
 
 dotenv.config();
 
@@ -10,14 +16,27 @@ const PORT = process.env.PORT || 3001;
 
 app.use(express.json());
 
+// ===== ルート設定 =====
+
 // ヘルスチェック
 app.get('/', (req, res) => {
   res.json({
     status: 'ok',
     service: 'Shift Reminder Service',
     timestamp: new Date().toISOString(),
+    endpoints: {
+      webhook: '/api/webhook/line',
+      notification: '/api/notification/*',
+      sendReminder: '/api/send-reminder',
+    },
   });
 });
+
+// LINE Webhook
+app.use('/api/webhook', webhookRouter);
+
+// 通知API（第1案・第2案承認通知）
+app.use('/api/notification', notificationRouter);
 
 // 手動でリマインダーを送信するエンドポイント（テスト用）
 app.post('/api/send-reminder', async (req, res) => {
@@ -35,7 +54,7 @@ app.post('/api/send-reminder', async (req, res) => {
 
     res.json({
       success: true,
-      message: `Reminders sent for ${year}/${month}`,
+      message: `Reminder check completed for ${year}/${month}`,
       ...result,
     });
   } catch (error) {
@@ -47,29 +66,61 @@ app.post('/api/send-reminder', async (req, res) => {
   }
 });
 
-// Cronジョブ: 毎月5日と8日の10:00に翌月分のリマインドを送信
-// '0 10 5,8 * *' = 毎月5日と8日の10:00
-cron.schedule('0 10 5,8 * *', () => {
-  const now = new Date();
-  const targetYear =
-    now.getMonth() === 11 ? now.getFullYear() + 1 : now.getFullYear();
-  const targetMonth = now.getMonth() === 11 ? 1 : now.getMonth() + 2;
+// 自動リマインド実行（テスト用）
+app.post('/api/send-auto-reminder', async (req, res) => {
+  try {
+    const result = await sendAutoReminder();
 
-  console.log(
-    `⏰ Cron job triggered: Sending reminders for ${targetYear}/${targetMonth}`
-  );
-  sendShiftReminders(targetYear, targetMonth)
-    .then(result => {
-      console.log('✅ Cron job completed:', result);
-    })
-    .catch(error => {
-      console.error('❌ Cron job failed:', error);
+    res.json({
+      success: true,
+      message: 'Auto reminder executed',
+      ...result,
     });
+  } catch (error) {
+    console.error('Error in auto reminder:', error);
+    res.status(500).json({
+      success: false,
+      error: error.message,
+    });
+  }
 });
 
+// ===== Cronジョブ設定 =====
+
+const config = getNotificationConfig();
+const cronSchedule = config.cronSchedule || '0 9 * * *';
+
+// 毎日定時にリマインド通知をチェック
+cron.schedule(cronSchedule, async () => {
+  console.log('⏰ Cron job triggered at', new Date().toISOString());
+
+  try {
+    const result = await sendAutoReminder();
+    console.log('✅ Cron job completed:', result);
+  } catch (error) {
+    console.error('❌ Cron job failed:', error);
+  }
+});
+
+// ===== サーバー起動 =====
+
 app.listen(PORT, () => {
+  console.log('===========================================');
   console.log(`🚀 Shift Reminder Service running on port ${PORT}`);
   console.log(
-    '📅 Cron job scheduled: Reminders will be sent on 5th and 8th of each month at 10:00'
+    `📅 Cron schedule: ${cronSchedule} (${config.settings.timezone})`
   );
+  console.log(
+    `📵 Notification enabled: ${process.env.NOTIFICATION_ENABLED !== 'false'}`
+  );
+  console.log('===========================================');
+  console.log('Available endpoints:');
+  console.log('  GET  /                           - Health check');
+  console.log('  POST /api/webhook/line           - LINE Webhook');
+  console.log('  POST /api/notification/first-plan-approved');
+  console.log('  POST /api/notification/second-plan-approved');
+  console.log('  POST /api/notification/test      - Test notification');
+  console.log('  POST /api/send-reminder          - Manual reminder');
+  console.log('  POST /api/send-auto-reminder     - Auto reminder');
+  console.log('===========================================');
 });

--- a/backend/src/routes/notification.js
+++ b/backend/src/routes/notification.js
@@ -1,0 +1,190 @@
+import express from 'express';
+import {
+  getGroupIdByTenant,
+  sendGroupMessage,
+  formatMessage,
+  getLiffUrl,
+  getNotificationConfig,
+} from '../services/lineService.js';
+import { getDeadlineString } from '../services/reminderService.js';
+import { getPartTimeDeadlineSettings } from '../services/submissionService.js';
+
+const router = express.Router();
+
+/**
+ * 第1案承認通知
+ * POST /api/notification/first-plan-approved
+ *
+ * shift-scheduler-ai から呼び出される
+ * グループに「シフト希望入力開始」を通知
+ */
+router.post('/first-plan-approved', async (req, res) => {
+  try {
+    const { tenant_id, store_id, plan_id, year, month } = req.body;
+
+    console.log('📢 First plan approved notification request:', {
+      tenant_id,
+      store_id,
+      plan_id,
+      year,
+      month,
+    });
+
+    // バリデーション
+    if (!tenant_id || !year || !month) {
+      return res.status(400).json({
+        success: false,
+        error: 'Missing required parameters: tenant_id, year, month',
+      });
+    }
+
+    // グループID取得
+    const groupId = getGroupIdByTenant(tenant_id);
+    if (!groupId) {
+      console.warn(`⚠️ No group configured for tenant ${tenant_id}`);
+      return res.json({
+        success: true,
+        message: 'No group configured for this tenant. Notification skipped.',
+        notified: false,
+      });
+    }
+
+    // DBからアルバイトの締切設定を取得
+    const deadlineSettings = await getPartTimeDeadlineSettings(tenant_id);
+    console.log('📋 Deadline settings from DB:', deadlineSettings);
+
+    // メッセージ作成（DBの締切日を使用）
+    const config = getNotificationConfig();
+    const template = config.approvalMessages.firstPlanApproved;
+    const message = formatMessage(template, {
+      targetMonth: month,
+      deadline: getDeadlineString(year, month, deadlineSettings.deadline_day),
+      liffUrl: getLiffUrl(),
+    });
+
+    // グループに送信
+    const sent = await sendGroupMessage(groupId, message);
+
+    res.json({
+      success: true,
+      message: sent
+        ? 'Notification sent to group'
+        : 'Notification skipped (disabled)',
+      notified: sent,
+    });
+  } catch (error) {
+    console.error('❌ Error in first-plan-approved:', error);
+    res.status(500).json({
+      success: false,
+      error: error.message,
+    });
+  }
+});
+
+/**
+ * 第2案承認通知（フェーズ5）
+ * POST /api/notification/second-plan-approved
+ *
+ * shift-scheduler-ai から呼び出される
+ * グループに「シフト確定」を通知
+ */
+router.post('/second-plan-approved', async (req, res) => {
+  try {
+    const { tenant_id, store_id, plan_id, year, month } = req.body;
+
+    console.log('📢 Second plan approved notification request:', {
+      tenant_id,
+      store_id,
+      plan_id,
+      year,
+      month,
+    });
+
+    // バリデーション
+    if (!tenant_id || !year || !month) {
+      return res.status(400).json({
+        success: false,
+        error: 'Missing required parameters: tenant_id, year, month',
+      });
+    }
+
+    // グループID取得
+    const groupId = getGroupIdByTenant(tenant_id);
+    if (!groupId) {
+      console.warn(`⚠️ No group configured for tenant ${tenant_id}`);
+      return res.json({
+        success: true,
+        message: 'No group configured for this tenant. Notification skipped.',
+        notified: false,
+      });
+    }
+
+    // メッセージ作成
+    const config = getNotificationConfig();
+    const template = config.approvalMessages.secondPlanApproved;
+    const message = formatMessage(template, {
+      targetMonth: month,
+      liffUrl: getLiffUrl(),
+    });
+
+    // グループに送信
+    const sent = await sendGroupMessage(groupId, message);
+
+    res.json({
+      success: true,
+      message: sent
+        ? 'Notification sent to group'
+        : 'Notification skipped (disabled)',
+      notified: sent,
+    });
+  } catch (error) {
+    console.error('❌ Error in second-plan-approved:', error);
+    res.status(500).json({
+      success: false,
+      error: error.message,
+    });
+  }
+});
+
+/**
+ * テスト用：手動で通知を送信
+ * POST /api/notification/test
+ *
+ * ローカル開発・テスト用エンドポイント
+ */
+router.post('/test', async (req, res) => {
+  try {
+    const { tenant_id, message } = req.body;
+
+    if (!tenant_id || !message) {
+      return res.status(400).json({
+        success: false,
+        error: 'Missing required parameters: tenant_id, message',
+      });
+    }
+
+    const groupId = getGroupIdByTenant(tenant_id);
+    if (!groupId) {
+      return res.status(400).json({
+        success: false,
+        error: `No group configured for tenant ${tenant_id}`,
+      });
+    }
+
+    const sent = await sendGroupMessage(groupId, message);
+
+    res.json({
+      success: true,
+      message: sent ? 'Test message sent' : 'Test message skipped (disabled)',
+      groupId: groupId,
+    });
+  } catch (error) {
+    console.error('❌ Error in test notification:', error);
+    res.status(500).json({
+      success: false,
+      error: error.message,
+    });
+  }
+});
+
+export default router;

--- a/backend/src/routes/webhook.js
+++ b/backend/src/routes/webhook.js
@@ -1,0 +1,85 @@
+import express from 'express';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const router = express.Router();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * LINE Webhook エンドポイント
+ * POST /api/webhook/line
+ *
+ * LINE Platform からの Webhook イベントを受信
+ * 主にグループ参加時のグループID取得に使用
+ */
+router.post('/line', async (req, res) => {
+  try {
+    const events = req.body.events || [];
+
+    console.log('📨 Webhook received:', events.length, 'events');
+
+    for (const event of events) {
+      // グループ参加イベント
+      if (event.type === 'join' && event.source.type === 'group') {
+        const groupId = event.source.groupId;
+        const timestamp = new Date(event.timestamp).toISOString();
+
+        console.log('===========================================');
+        console.log('🎉 Bot joined a new group!');
+        console.log('Group ID:', groupId);
+        console.log('Timestamp:', timestamp);
+        console.log('===========================================');
+
+        // ファイルにも記録（ローカル開発用）
+        try {
+          const dataDir = path.join(__dirname, '..', 'data');
+          const logPath = path.join(dataDir, 'group-ids.log');
+
+          // dataディレクトリが存在しない場合は作成
+          if (!fs.existsSync(dataDir)) {
+            fs.mkdirSync(dataDir, { recursive: true });
+          }
+
+          const logLine = `${timestamp} | Group ID: ${groupId}\n`;
+          fs.appendFileSync(logPath, logLine);
+          console.log('📝 Group ID saved to:', logPath);
+        } catch (fileError) {
+          // ファイル書き込みエラーは警告のみ（本番環境では失敗する可能性あり）
+          console.warn('⚠️ Could not save to file:', fileError.message);
+        }
+      }
+
+      // グループ退出イベント
+      if (event.type === 'leave' && event.source.type === 'group') {
+        console.log('👋 Bot left group:', event.source.groupId);
+      }
+
+      // メッセージイベント（将来の拡張用）
+      if (event.type === 'message') {
+        console.log('💬 Message received from:', event.source.type);
+        // 現時点ではメッセージには応答しない
+      }
+    }
+
+    // LINE Platform には常に 200 OK を返す
+    res.status(200).send('OK');
+  } catch (error) {
+    console.error('❌ Webhook error:', error);
+    // エラーでも 200 を返す（LINE が再送を繰り返さないように）
+    res.status(200).send('OK');
+  }
+});
+
+/**
+ * Webhook 検証用エンドポイント
+ * GET /api/webhook/line
+ *
+ * LINE Developers Console での Webhook URL 検証に使用
+ */
+router.get('/line', (req, res) => {
+  res.status(200).send('Webhook endpoint is active');
+});
+
+export default router;

--- a/backend/src/services/lineService.js
+++ b/backend/src/services/lineService.js
@@ -1,0 +1,133 @@
+import { messagingApi } from '@line/bot-sdk';
+import { createRequire } from 'module';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const require = createRequire(import.meta.url);
+const notificationConfig = require('../config/line-notification.json');
+
+// LINE Messaging API クライアント
+const client = new messagingApi.MessagingApiClient({
+  channelAccessToken: process.env.LINE_CHANNEL_ACCESS_TOKEN,
+});
+
+/**
+ * テナントIDからグループIDを取得
+ * @param {number} tenantId - テナントID
+ * @returns {string|null} グループID
+ */
+export function getGroupIdByTenant(tenantId) {
+  const tenantKey = `tenant_${tenantId}`;
+  const group = notificationConfig.groups[tenantKey];
+
+  if (!group || !group.groupId) {
+    console.warn(`⚠️ Group ID not configured for tenant ${tenantId}`);
+    return null;
+  }
+
+  return group.groupId;
+}
+
+/**
+ * グループにメッセージを送信
+ * @param {string} groupId - LINEグループID
+ * @param {string} message - 送信メッセージ
+ * @returns {Promise<boolean>} 送信成功したかどうか
+ */
+export async function sendGroupMessage(groupId, message) {
+  // 通知が無効化されている場合はスキップ
+  if (process.env.NOTIFICATION_ENABLED === 'false') {
+    console.log('📵 Notification is disabled. Skipping group message.');
+    console.log('Message would be:', message);
+    return true;
+  }
+
+  if (!groupId) {
+    console.error('❌ Group ID is not provided');
+    return false;
+  }
+
+  try {
+    await client.pushMessage({
+      to: groupId,
+      messages: [
+        {
+          type: 'text',
+          text: message,
+        },
+      ],
+    });
+    console.log(`✅ Group message sent to ${groupId}`);
+    return true;
+  } catch (error) {
+    console.error('❌ Error sending group message:', error.message);
+    return false;
+  }
+}
+
+/**
+ * 個人にメッセージを送信
+ * @param {string} userId - LINE User ID
+ * @param {string} message - 送信メッセージ
+ * @returns {Promise<boolean>} 送信成功したかどうか
+ */
+export async function sendIndividualMessage(userId, message) {
+  // 通知が無効化されている場合はスキップ
+  if (process.env.NOTIFICATION_ENABLED === 'false') {
+    console.log('📵 Notification is disabled. Skipping individual message.');
+    console.log('Message would be:', message);
+    return true;
+  }
+
+  try {
+    await client.pushMessage({
+      to: userId,
+      messages: [
+        {
+          type: 'text',
+          text: message,
+        },
+      ],
+    });
+    console.log(`✅ Message sent to ${userId}`);
+    return true;
+  } catch (error) {
+    console.error(`❌ Error sending message to ${userId}:`, error.message);
+    return false;
+  }
+}
+
+/**
+ * メッセージテンプレートの変数を置換
+ * @param {string} template - メッセージテンプレート
+ * @param {Object} variables - 置換する変数
+ * @returns {string} 置換後のメッセージ
+ */
+export function formatMessage(template, variables) {
+  let message = template;
+
+  for (const [key, value] of Object.entries(variables)) {
+    const placeholder = `{${key}}`;
+    message = message.replace(new RegExp(placeholder, 'g'), value);
+  }
+
+  return message;
+}
+
+/**
+ * LIFF URLを生成
+ * @returns {string} LIFF URL
+ */
+export function getLiffUrl() {
+  const liffId = process.env.LIFF_ID || '2008227932-Rq9rJrJn';
+  return `https://liff.line.me/${liffId}`;
+}
+
+/**
+ * 設定ファイルを取得
+ * @returns {Object} 通知設定
+ */
+export function getNotificationConfig() {
+  return notificationConfig;
+}

--- a/backend/src/services/reminderService.js
+++ b/backend/src/services/reminderService.js
@@ -1,147 +1,201 @@
-import { messagingApi } from '@line/bot-sdk';
 import dotenv from 'dotenv';
-import pool from '../config/database.js';
+import {
+  getGroupIdByTenant,
+  sendGroupMessage,
+  formatMessage,
+  getLiffUrl,
+  getNotificationConfig,
+} from './lineService.js';
+import {
+  getPartTimeSubmissionStats,
+  getUnsubmittedNamesString,
+  getPartTimeDeadlineSettings,
+} from './submissionService.js';
 
 dotenv.config();
 
-const client = new messagingApi.MessagingApiClient({
-  channelAccessToken: process.env.LINE_CHANNEL_ACCESS_TOKEN,
-});
-
 /**
- * シフト未提出のアルバイトスタッフを取得
+ * 締切日までの残り日数を計算
  * @param {number} year - 対象年
  * @param {number} month - 対象月
- * @returns {Promise<Array>} - 未提出スタッフのリスト
+ * @param {number} deadlineDay - 締切日（1-31）
+ * @param {string} deadlineTime - 締切時刻（"HH:MM"形式）
+ * @returns {number} 残り日数（負の値は締切超過）
  */
-export async function getUnsubmittedPartTimeStaff(year, month) {
-  const tenantId = process.env.TENANT_ID || 3;
+export function getDaysUntilDeadline(
+  year,
+  month,
+  deadlineDay,
+  deadlineTime = '23:59'
+) {
+  // N月のシフト締切はN-1月のdeadlineDay日
+  let deadlineMonth = month - 1;
+  let deadlineYear = year;
 
-  const query = `
-    SELECT
-      sla.line_user_id,
-      s.staff_id,
-      s.name,
-      s.employment_type,
-      st.store_name
-    FROM hr.staff_line_accounts sla
-    JOIN hr.staff s ON sla.staff_id = s.staff_id
-    JOIN core.stores st ON s.store_id = st.store_id
-    JOIN core.employment_types et ON s.employment_type = et.employment_code AND et.tenant_id = s.tenant_id
-    WHERE sla.tenant_id = $1
-      AND sla.is_active = true
-      AND s.is_active = true
-      AND et.payment_type = 'HOURLY'
-      AND NOT EXISTS (
-        SELECT 1 FROM ops.shift_preferences sp
-        WHERE sp.staff_id = s.staff_id
-          AND sp.year = $2
-          AND sp.month = $3
-      )
-  `;
-
-  try {
-    const result = await pool.query(query, [tenantId, year, month]);
-    return result.rows;
-  } catch (error) {
-    console.error('❌ Error fetching unsubmitted staff:', error);
-    throw error;
+  if (deadlineMonth === 0) {
+    deadlineMonth = 12;
+    deadlineYear--;
   }
+
+  // 締切時刻をパース
+  const [hour, minute] = deadlineTime.split(':').map(Number);
+
+  const deadline = new Date(
+    deadlineYear,
+    deadlineMonth - 1,
+    deadlineDay,
+    hour,
+    minute,
+    59
+  );
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const diffTime = deadline.getTime() - today.getTime();
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+  return diffDays;
 }
 
 /**
- * LINEプッシュメッセージ送信
- * @param {string} userId - LINE User ID
- * @param {string} message - 送信メッセージ
+ * 締切日文字列を生成
+ * @param {number} year - 対象年
+ * @param {number} month - 対象月
+ * @param {number} deadlineDay - 締切日
+ * @returns {string} 締切日文字列（例: "12月10日"）
  */
-export async function sendLineMessage(userId, message) {
-  try {
-    await client.pushMessage({
-      to: userId,
-      messages: [
-        {
-          type: 'text',
-          text: message,
-        },
-      ],
-    });
-    console.log(`✅ Message sent to ${userId}`);
-  } catch (error) {
-    console.error(`❌ Error sending message to ${userId}:`, error);
-    throw error;
+export function getDeadlineString(year, month, deadlineDay) {
+  // N月のシフト締切はN-1月のdeadlineDay日
+  let deadlineMonth = month - 1;
+
+  if (deadlineMonth === 0) {
+    deadlineMonth = 12;
   }
+
+  return `${deadlineMonth}月${deadlineDay}日`;
 }
 
 /**
- * シフト提出リマインダーを送信
+ * 残り日数からフェーズを判定
+ * @param {number} daysUntilDeadline - 締切までの残り日数
+ * @returns {Object|null} 該当するフェーズ設定（該当なしはnull）
+ */
+export function determinePhase(daysUntilDeadline) {
+  const config = getNotificationConfig();
+  const reminders = config.reminders;
+
+  // フェーズ4: 締切後（0日以下）
+  if (daysUntilDeadline <= 0) {
+    return reminders.find(r => r.phase === 4);
+  }
+
+  // フェーズ1〜3: 残り日数に応じて判定
+  for (const reminder of reminders) {
+    if (reminder.daysBefore === daysUntilDeadline) {
+      return reminder;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * リマインド通知を送信（cron から呼び出される）
  * @param {number} year - 対象年
  * @param {number} month - 対象月
+ * @returns {Promise<Object>} 送信結果
  */
+export async function sendReminderNotification(year, month) {
+  const tenantId = parseInt(process.env.TENANT_ID, 10) || 3;
+
+  console.log(`📅 Checking reminder for ${year}/${month}, tenant ${tenantId}`);
+
+  // DBからアルバイトの締切設定を取得
+  const deadlineSettings = await getPartTimeDeadlineSettings(tenantId);
+  console.log('📋 Deadline settings from DB:', deadlineSettings);
+
+  // 残り日数を計算（DBの締切日を使用）
+  const daysUntilDeadline = getDaysUntilDeadline(
+    year,
+    month,
+    deadlineSettings.deadline_day,
+    deadlineSettings.deadline_time
+  );
+  console.log(`⏰ Days until deadline: ${daysUntilDeadline}`);
+
+  // フェーズを判定
+  const phase = determinePhase(daysUntilDeadline);
+
+  if (!phase) {
+    console.log('📭 No notification scheduled for today');
+    return { success: true, notified: false, reason: 'No phase matched' };
+  }
+
+  console.log(`📢 Phase ${phase.phase} (${phase.type}) triggered`);
+
+  // グループIDを取得
+  const groupId = getGroupIdByTenant(tenantId);
+  if (!groupId) {
+    console.warn(`⚠️ No group configured for tenant ${tenantId}`);
+    return { success: true, notified: false, reason: 'No group configured' };
+  }
+
+  // 統計情報を取得（フェーズ2, 3で使用）
+  const stats = await getPartTimeSubmissionStats(tenantId, year, month);
+  console.log('📊 Submission stats:', stats);
+
+  // 未提出者名を取得（フェーズ3で使用）
+  let unsubmittedNames = '';
+  if (phase.type === 'named') {
+    unsubmittedNames = await getUnsubmittedNamesString(tenantId, year, month);
+  }
+
+  // メッセージを作成（DBの締切日を使用）
+  const message = formatMessage(phase.message, {
+    targetMonth: month,
+    deadline: getDeadlineString(year, month, deadlineSettings.deadline_day),
+    liffUrl: getLiffUrl(),
+    totalCount: stats.totalCount,
+    submittedCount: stats.submittedCount,
+    unsubmittedCount: stats.unsubmittedCount,
+    unsubmittedNames: unsubmittedNames,
+  });
+
+  // グループに送信
+  const sent = await sendGroupMessage(groupId, message);
+
+  return {
+    success: true,
+    notified: sent,
+    phase: phase.phase,
+    type: phase.type,
+    stats: stats,
+    deadlineSettings: deadlineSettings,
+  };
+}
+
+/**
+ * 対象月を自動計算してリマインドを送信
+ * cronジョブから呼び出される場合に使用
+ */
+export async function sendAutoReminder() {
+  const now = new Date();
+
+  // 現在の日付から対象月を判定（来月分のシフト）
+  let targetYear = now.getFullYear();
+  let targetMonth = now.getMonth() + 2; // 来月分
+
+  if (targetMonth > 12) {
+    targetMonth = 1;
+    targetYear++;
+  }
+
+  console.log(`🤖 Auto reminder: targeting ${targetYear}/${targetMonth}`);
+
+  return await sendReminderNotification(targetYear, targetMonth);
+}
+
+// 旧関数との互換性を維持（既存のcronジョブ用）
 export async function sendShiftReminders(year, month) {
-  console.log(`📅 Sending shift reminders for ${year}/${month}`);
-
-  try {
-    const unsubmittedStaff = await getUnsubmittedPartTimeStaff(year, month);
-
-    if (unsubmittedStaff.length === 0) {
-      console.log(
-        '✅ All part-time staff have submitted their shift preferences'
-      );
-      return { success: true, count: 0 };
-    }
-
-    console.log(
-      `📝 Found ${unsubmittedStaff.length} staff who haven't submitted`
-    );
-
-    // 締切日を計算（N月の締切 = N-1月10日）
-    let deadlineMonth = month - 1;
-    let deadlineYear = year;
-    if (deadlineMonth === 0) {
-      deadlineMonth = 12;
-      deadlineYear--;
-    }
-
-    const results = [];
-    for (const staff of unsubmittedStaff) {
-      const message = `【シフト提出リマインド】
-
-${staff.name} さん、こんにちは！
-
-${year}年${month}月のシフト希望がまだ提出されていません。
-
-📅 提出期限: ${deadlineYear}年${deadlineMonth}月10日 23:59
-
-以下のリンクからシフト希望を入力してください：
-https://liff.line.me/${process.env.LIFF_ID || '2008227932-Rq9rJrJn'}
-
-ご協力をお願いいたします。`;
-
-      try {
-        await sendLineMessage(staff.line_user_id, message);
-        results.push({
-          staff_id: staff.staff_id,
-          name: staff.name,
-          success: true,
-        });
-      } catch (error) {
-        results.push({
-          staff_id: staff.staff_id,
-          name: staff.name,
-          success: false,
-          error: error.message,
-        });
-      }
-    }
-
-    const successCount = results.filter(r => r.success).length;
-    console.log(
-      `✅ Sent ${successCount}/${results.length} reminders successfully`
-    );
-
-    return { success: true, count: results.length, results };
-  } catch (error) {
-    console.error('❌ Error in sendShiftReminders:', error);
-    throw error;
-  }
+  return await sendReminderNotification(year, month);
 }

--- a/backend/src/services/submissionService.js
+++ b/backend/src/services/submissionService.js
@@ -1,0 +1,198 @@
+import pool from '../config/database.js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+/**
+ * アルバイトスタッフのシフト提出状況を取得
+ * @param {number} tenantId - テナントID
+ * @param {number} year - 対象年
+ * @param {number} month - 対象月
+ * @returns {Promise<Object>} 提出状況の統計情報
+ */
+export async function getPartTimeSubmissionStats(tenantId, year, month) {
+  // アルバイト（HOURLY）の総数を取得
+  const totalQuery = `
+    SELECT COUNT(*) as total_count
+    FROM hr.staff s
+    JOIN hr.staff_line_accounts sla ON s.staff_id = sla.staff_id AND s.tenant_id = sla.tenant_id
+    JOIN core.employment_types et ON s.employment_type = et.employment_code AND et.tenant_id = s.tenant_id
+    WHERE s.tenant_id = $1
+      AND s.is_active = true
+      AND sla.is_active = true
+      AND et.payment_type = 'HOURLY'
+  `;
+
+  // 提出済みアルバイトの数を取得
+  const submittedQuery = `
+    SELECT COUNT(DISTINCT s.staff_id) as submitted_count
+    FROM hr.staff s
+    JOIN hr.staff_line_accounts sla ON s.staff_id = sla.staff_id AND s.tenant_id = sla.tenant_id
+    JOIN core.employment_types et ON s.employment_type = et.employment_code AND et.tenant_id = s.tenant_id
+    JOIN ops.shift_preferences sp ON s.staff_id = sp.staff_id
+    WHERE s.tenant_id = $1
+      AND s.is_active = true
+      AND sla.is_active = true
+      AND et.payment_type = 'HOURLY'
+      AND sp.year = $2
+      AND sp.month = $3
+  `;
+
+  try {
+    const [totalResult, submittedResult] = await Promise.all([
+      pool.query(totalQuery, [tenantId]),
+      pool.query(submittedQuery, [tenantId, year, month]),
+    ]);
+
+    const totalCount = parseInt(totalResult.rows[0].total_count, 10);
+    const submittedCount = parseInt(
+      submittedResult.rows[0].submitted_count,
+      10
+    );
+    const unsubmittedCount = totalCount - submittedCount;
+
+    return {
+      totalCount,
+      submittedCount,
+      unsubmittedCount,
+    };
+  } catch (error) {
+    console.error('❌ Error getting submission stats:', error);
+    throw error;
+  }
+}
+
+/**
+ * 未提出のアルバイトスタッフ一覧を取得
+ * @param {number} tenantId - テナントID
+ * @param {number} year - 対象年
+ * @param {number} month - 対象月
+ * @returns {Promise<Array>} 未提出スタッフの配列
+ */
+export async function getUnsubmittedPartTimeStaff(tenantId, year, month) {
+  const query = `
+    SELECT
+      sla.line_user_id,
+      s.staff_id,
+      s.name,
+      s.employment_type,
+      st.store_name
+    FROM hr.staff_line_accounts sla
+    JOIN hr.staff s ON sla.staff_id = s.staff_id AND sla.tenant_id = s.tenant_id
+    JOIN core.stores st ON s.store_id = st.store_id
+    JOIN core.employment_types et ON s.employment_type = et.employment_code AND et.tenant_id = s.tenant_id
+    WHERE sla.tenant_id = $1
+      AND sla.is_active = true
+      AND s.is_active = true
+      AND et.payment_type = 'HOURLY'
+      AND NOT EXISTS (
+        SELECT 1 FROM ops.shift_preferences sp
+        WHERE sp.staff_id = s.staff_id
+          AND sp.year = $2
+          AND sp.month = $3
+      )
+    ORDER BY s.name
+  `;
+
+  try {
+    const result = await pool.query(query, [tenantId, year, month]);
+    return result.rows;
+  } catch (error) {
+    console.error('❌ Error fetching unsubmitted staff:', error);
+    throw error;
+  }
+}
+
+/**
+ * 未提出者の名前一覧を文字列で取得
+ * @param {number} tenantId - テナントID
+ * @param {number} year - 対象年
+ * @param {number} month - 対象月
+ * @returns {Promise<string>} 名前一覧（改行区切り）
+ */
+export async function getUnsubmittedNamesString(tenantId, year, month) {
+  const staff = await getUnsubmittedPartTimeStaff(tenantId, year, month);
+
+  if (staff.length === 0) {
+    return '（なし）';
+  }
+
+  // 名前をリスト形式で返す
+  return staff.map((s, index) => `${index + 1}. ${s.name}`).join('\n');
+}
+
+/**
+ * アルバイト（PART_TIME）の締切設定をDBから取得
+ * @param {number} tenantId - テナントID
+ * @returns {Promise<Object>} 締切設定 { deadline_day, deadline_time, is_enabled }
+ */
+export async function getPartTimeDeadlineSettings(tenantId) {
+  const query = `
+    SELECT deadline_day, deadline_time, is_enabled
+    FROM core.shift_deadline_settings
+    WHERE tenant_id = $1 AND employment_type = 'PART_TIME'
+  `;
+
+  try {
+    const result = await pool.query(query, [tenantId]);
+
+    if (result.rows.length === 0) {
+      // デフォルト値を返す
+      console.warn(
+        `⚠️ No deadline settings found for tenant ${tenantId}, using defaults`
+      );
+      return {
+        deadline_day: 10,
+        deadline_time: '23:59',
+        is_enabled: true,
+      };
+    }
+
+    return {
+      deadline_day: result.rows[0].deadline_day,
+      deadline_time: result.rows[0].deadline_time || '23:59',
+      is_enabled: result.rows[0].is_enabled,
+    };
+  } catch (error) {
+    console.error('❌ Error fetching deadline settings:', error);
+    // エラー時はデフォルト値
+    return {
+      deadline_day: 10,
+      deadline_time: '23:59',
+      is_enabled: true,
+    };
+  }
+}
+
+/**
+ * 全アルバイトスタッフを取得（LINE User ID付き）
+ * @param {number} tenantId - テナントID
+ * @returns {Promise<Array>} スタッフの配列
+ */
+export async function getAllPartTimeStaffWithLineId(tenantId) {
+  const query = `
+    SELECT
+      sla.line_user_id,
+      s.staff_id,
+      s.name,
+      s.employment_type,
+      st.store_name
+    FROM hr.staff_line_accounts sla
+    JOIN hr.staff s ON sla.staff_id = s.staff_id AND sla.tenant_id = s.tenant_id
+    JOIN core.stores st ON s.store_id = st.store_id
+    JOIN core.employment_types et ON s.employment_type = et.employment_code AND et.tenant_id = s.tenant_id
+    WHERE sla.tenant_id = $1
+      AND sla.is_active = true
+      AND s.is_active = true
+      AND et.payment_type = 'HOURLY'
+    ORDER BY s.name
+  `;
+
+  try {
+    const result = await pool.query(query, [tenantId]);
+    return result.rows;
+  } catch (error) {
+    console.error('❌ Error fetching all part-time staff:', error);
+    throw error;
+  }
+}

--- a/docs/design-docs/line-notification-design-v2.html
+++ b/docs/design-docs/line-notification-design-v2.html
@@ -1,0 +1,1459 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LINE通知機能 設計書 v2</title>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+          'Hiragino Sans', sans-serif;
+        background: #f8f9fa;
+        color: #333;
+        line-height: 1.7;
+        padding: 40px 20px;
+      }
+      .container {
+        max-width: 900px;
+        margin: 0 auto;
+      }
+      h1 {
+        color: #06c755;
+        font-size: 1.8rem;
+        margin-bottom: 10px;
+        padding-bottom: 10px;
+        border-bottom: 3px solid #06c755;
+      }
+      .meta {
+        color: #666;
+        font-size: 0.9rem;
+        margin-bottom: 30px;
+      }
+      h2 {
+        color: #333;
+        font-size: 1.4rem;
+        margin-top: 40px;
+        margin-bottom: 15px;
+        padding-left: 10px;
+        border-left: 4px solid #06c755;
+      }
+      h3 {
+        color: #555;
+        font-size: 1.1rem;
+        margin-top: 25px;
+        margin-bottom: 10px;
+      }
+      h4 {
+        color: #666;
+        font-size: 1rem;
+        margin-top: 20px;
+        margin-bottom: 8px;
+      }
+      p {
+        margin-bottom: 15px;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 15px 0;
+        font-size: 0.9rem;
+      }
+      th,
+      td {
+        border: 1px solid #ddd;
+        padding: 10px 12px;
+        text-align: left;
+      }
+      th {
+        background: #f0f0f0;
+        font-weight: bold;
+      }
+      tr:nth-child(even) {
+        background: #fafafa;
+      }
+      .highlight {
+        background: #e8f5e9;
+      }
+      .warning {
+        background: #fff3cd;
+      }
+      code {
+        background: #f4f4f4;
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-family: 'Courier New', monospace;
+        font-size: 0.9em;
+      }
+      pre {
+        background: #2d2d2d;
+        color: #f8f8f2;
+        padding: 15px;
+        border-radius: 8px;
+        overflow-x: auto;
+        margin: 15px 0;
+        font-size: 0.85rem;
+      }
+      .card {
+        background: white;
+        border-radius: 8px;
+        padding: 20px;
+        margin: 20px 0;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
+      .pros {
+        color: #28a745;
+      }
+      .cons {
+        color: #dc3545;
+      }
+      .badge {
+        display: inline-block;
+        padding: 3px 8px;
+        border-radius: 4px;
+        font-size: 0.8rem;
+        font-weight: bold;
+      }
+      .badge-green {
+        background: #d4edda;
+        color: #155724;
+      }
+      .badge-yellow {
+        background: #fff3cd;
+        color: #856404;
+      }
+      .badge-blue {
+        background: #cce5ff;
+        color: #004085;
+      }
+      .badge-red {
+        background: #f8d7da;
+        color: #721c24;
+      }
+      .badge-new {
+        background: #ff6b6b;
+        color: white;
+      }
+      .badge-modify {
+        background: #ffa726;
+        color: white;
+      }
+      .badge-none {
+        background: #e0e0e0;
+        color: #666;
+      }
+      .recommendation {
+        background: linear-gradient(135deg, #e8f5e9 0%, #c8e6c9 100%);
+        border: 2px solid #4caf50;
+        border-radius: 8px;
+        padding: 20px;
+        margin: 20px 0;
+      }
+      .recommendation h3 {
+        color: #2e7d32;
+        margin-top: 0;
+      }
+      .glossary {
+        background: #e3f2fd;
+        border: 1px solid #90caf9;
+        border-radius: 8px;
+        padding: 20px;
+        margin: 20px 0;
+      }
+      .glossary h3 {
+        color: #1565c0;
+        margin-top: 0;
+      }
+      ul {
+        margin: 10px 0 15px 20px;
+      }
+      li {
+        margin-bottom: 5px;
+      }
+      .flow-diagram {
+        background: #fff;
+        border: 1px solid #ddd;
+        border-radius: 8px;
+        padding: 20px;
+        text-align: center;
+        margin: 15px 0;
+      }
+      .flow-step {
+        display: inline-block;
+        background: #e3f2fd;
+        border: 1px solid #90caf9;
+        border-radius: 4px;
+        padding: 8px 15px;
+        margin: 5px;
+      }
+      .flow-arrow {
+        display: inline-block;
+        color: #666;
+        margin: 0 5px;
+      }
+      .impact-section {
+        background: #fff8e1;
+        border: 2px solid #ffb300;
+        border-radius: 8px;
+        padding: 20px;
+        margin: 20px 0;
+      }
+      .impact-section h3 {
+        color: #ff8f00;
+        margin-top: 0;
+      }
+      .new-file {
+        background: #ffebee;
+      }
+      .file-tree {
+        background: #263238;
+        color: #aed581;
+        padding: 15px;
+        border-radius: 8px;
+        font-family: 'Courier New', monospace;
+        font-size: 0.85rem;
+        margin: 15px 0;
+      }
+      .file-tree .new {
+        color: #ff6b6b;
+      }
+      .file-tree .modify {
+        color: #ffa726;
+      }
+      .file-tree .existing {
+        color: #aed581;
+      }
+      .file-tree .comment {
+        color: #78909c;
+      }
+      .version-badge {
+        display: inline-block;
+        background: #06c755;
+        color: white;
+        padding: 4px 12px;
+        border-radius: 20px;
+        font-size: 0.85rem;
+        margin-left: 10px;
+      }
+      .changed {
+        background: #fff9c4;
+        border-left: 4px solid #ffc107;
+        padding-left: 10px;
+      }
+      .api-spec {
+        background: #f5f5f5;
+        border: 1px solid #ddd;
+        border-radius: 8px;
+        padding: 15px;
+        margin: 15px 0;
+      }
+      .api-spec h4 {
+        margin-top: 0;
+        color: #1565c0;
+      }
+      .http-method {
+        display: inline-block;
+        padding: 2px 8px;
+        border-radius: 4px;
+        font-weight: bold;
+        font-size: 0.85rem;
+      }
+      .http-post {
+        background: #49cc90;
+        color: white;
+      }
+      .http-get {
+        background: #61affe;
+        color: white;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>LINE通知機能 設計書 <span class="version-badge">v2.3</span></h1>
+      <div class="meta">
+        作成日: 2025-11-30 | 更新日: 2025-12-08 | 関連Issue: #130, #104 |
+        ステータス: 実装完了・STGテスト待ち
+      </div>
+
+      <!-- 変更履歴 -->
+      <div class="card changed">
+        <h3>v2.3 変更点（最新）</h3>
+        <ul>
+          <li>
+            <strong>shift-scheduler-ai統合</strong>: 承認処理からLIFF Backend
+            APIを呼び出す実装完了
+          </li>
+          <li>
+            <strong>第2案承認</strong>:
+            <code>PUT /plans/:plan_id/status</code> でステータスAPPROVED時に通知
+          </li>
+          <li><strong>環境変数</strong>: STG/PRDのLIFF_BACKEND_URLを明記</li>
+          <li>
+            <strong>テスト用API</strong>: 手動リマインド送信エンドポイントを追加
+          </li>
+        </ul>
+        <h3>v2.2 変更点</h3>
+        <ul>
+          <li>
+            <strong>締切日</strong>:
+            DBから動的取得に変更（<code>core.shift_deadline_settings</code>テーブル使用）
+          </li>
+          <li>
+            <strong>基準</strong>:
+            アルバイト（PART_TIME）の締切設定を全フェーズで使用
+          </li>
+          <li>
+            <strong>フォールバック</strong>: DB取得失敗時はデフォルト値（10日
+            23:59）を使用
+          </li>
+        </ul>
+        <h3>v2.1 変更点</h3>
+        <ul>
+          <li>
+            <strong>アーキテクチャ</strong>:
+            API呼び出し方式を採用（ベストプラクティス）
+          </li>
+          <li><strong>フェーズ4</strong>: 送信先を個人→グループに変更</li>
+          <li><strong>フェーズ5</strong>: 第2案承認後のグループ通知を追加</li>
+          <li>
+            <strong>フェーズ2, 3</strong>:
+            対象は<strong>アルバイトのみ</strong>と明記
+          </li>
+          <li>
+            <strong>shift-scheduler-ai</strong>:
+            軽微な修正が必要（API呼び出し追加）
+          </li>
+        </ul>
+      </div>
+
+      <!-- 用語解説 -->
+      <div class="glossary">
+        <h3>用語解説</h3>
+        <table>
+          <tr>
+            <th width="25%">用語</th>
+            <th>説明</th>
+          </tr>
+          <tr>
+            <td><strong>イベント駆動</strong></td>
+            <td>
+              アクション発生時に即座に処理を実行する方式。<br />
+              例: 承認ボタンクリック → 即座にLINE通知送信
+            </td>
+          </tr>
+          <tr>
+            <td><strong>Webhook</strong></td>
+            <td>
+              LINEからサーバーへの通知。Botがグループに参加した時などにLINEが自動でAPIを呼び出す。
+            </td>
+          </tr>
+          <tr>
+            <td><strong>cron</strong></td>
+            <td>
+              定期実行の仕組み。「毎日9時に実行」などのスケジュールを設定できる。
+            </td>
+          </tr>
+          <tr>
+            <td><strong>push message</strong></td>
+            <td>
+              LINE Messaging APIで、こちらから能動的にメッセージを送信する機能。
+            </td>
+          </tr>
+        </table>
+      </div>
+
+      <!-- 概要 -->
+      <h2>1. 概要</h2>
+      <p>
+        シフト希望入力に関する各種通知をLINE Messaging
+        APIを使用してグループに送信する機能を実装する。
+      </p>
+
+      <div class="card">
+        <h3>対象Issue</h3>
+        <table>
+          <tr>
+            <th>Issue</th>
+            <th>機能</th>
+            <th>トリガー</th>
+          </tr>
+          <tr>
+            <td>#130</td>
+            <td>リマインド・締切後通知（フェーズ1〜4）</td>
+            <td>cron（毎日定時実行）</td>
+          </tr>
+          <tr>
+            <td>#104</td>
+            <td>第1案承認通知・第2案承認通知（フェーズ5）</td>
+            <td>API呼び出し（イベント駆動）</td>
+          </tr>
+        </table>
+      </div>
+
+      <!-- アーキテクチャ選定 -->
+      <h2>2. アーキテクチャ選定</h2>
+
+      <div class="card">
+        <h3>API呼び出し方式 vs DBポーリング方式</h3>
+        <table>
+          <tr>
+            <th>比較項目</th>
+            <th>API呼び出し方式 <span class="badge badge-green">採用</span></th>
+            <th>DBポーリング方式</th>
+          </tr>
+          <tr>
+            <td>通知タイミング</td>
+            <td class="pros">リアルタイム（即時）</td>
+            <td>遅延あり（cronの間隔次第）</td>
+          </tr>
+          <tr>
+            <td>スケーラビリティ</td>
+            <td class="pros">高い（イベント駆動）</td>
+            <td>低い（定期的なDB負荷）</td>
+          </tr>
+          <tr>
+            <td>業界標準</td>
+            <td class="pros">推奨・一般的</td>
+            <td>レガシーな手法</td>
+          </tr>
+          <tr>
+            <td>shift-scheduler-ai変更</td>
+            <td>必要（軽微: 約10行追加）</td>
+            <td class="pros">不要</td>
+          </tr>
+          <tr>
+            <td>実装の明確さ</td>
+            <td class="pros">処理フローが明確</td>
+            <td>状態管理が複雑</td>
+          </tr>
+        </table>
+      </div>
+
+      <div class="recommendation">
+        <h3>採用: API呼び出し方式（イベント駆動）</h3>
+        <p><strong>理由:</strong></p>
+        <ul>
+          <li>業界標準のベストプラクティス</li>
+          <li>リアルタイム通知でユーザー体験向上</li>
+          <li>将来のテナント増加にも対応可能</li>
+          <li>shift-scheduler-aiへの変更は軽微（約10行の追加）</li>
+        </ul>
+      </div>
+
+      <!-- 影響範囲 -->
+      <h2>3. 影響範囲</h2>
+
+      <div class="impact-section">
+        <h3>各システムへの影響</h3>
+        <table>
+          <tr>
+            <th>システム</th>
+            <th>種類</th>
+            <th>影響</th>
+            <th>作業内容</th>
+          </tr>
+          <tr class="new-file">
+            <td><strong>shift-scheduler-ai-liff</strong><br />backend</td>
+            <td><span class="badge badge-new">新規追加</span></td>
+            <td>大</td>
+            <td>通知API、サービス、cronジョブの実装</td>
+          </tr>
+          <tr>
+            <td><strong>shift-scheduler-ai-liff</strong><br />frontend</td>
+            <td><span class="badge badge-none">影響なし</span></td>
+            <td>なし</td>
+            <td>変更不要</td>
+          </tr>
+          <tr class="warning">
+            <td><strong>shift-scheduler-ai</strong><br />backend</td>
+            <td><span class="badge badge-modify">軽微な修正</span></td>
+            <td>小</td>
+            <td>承認処理にAPI呼び出しを追加（約10行）</td>
+          </tr>
+          <tr>
+            <td><strong>shift-scheduler-ai</strong><br />frontend</td>
+            <td><span class="badge badge-none">影響なし</span></td>
+            <td>なし</td>
+            <td>変更不要</td>
+          </tr>
+          <tr>
+            <td><strong>データベース</strong></td>
+            <td><span class="badge badge-none">既存利用</span></td>
+            <td>なし</td>
+            <td>
+              締切設定を<code>core.shift_deadline_settings</code>から参照（変更不要）
+            </td>
+          </tr>
+        </table>
+      </div>
+
+      <!-- 機能要件 -->
+      <h2>4. 機能要件</h2>
+
+      <h3>4.1 通知フェーズ一覧</h3>
+      <table>
+        <tr>
+          <th>フェーズ</th>
+          <th>タイミング</th>
+          <th>送信先</th>
+          <th>対象者</th>
+          <th>内容</th>
+          <th>トリガー</th>
+        </tr>
+        <tr>
+          <td>1</td>
+          <td>締切7日前</td>
+          <td><span class="badge badge-green">グループ</span></td>
+          <td>全員向け</td>
+          <td>「まだの方は入力お願いします」（匿名）</td>
+          <td>cron</td>
+        </tr>
+        <tr class="changed">
+          <td>2</td>
+          <td>締切3日前</td>
+          <td><span class="badge badge-green">グループ</span></td>
+          <td><strong>アルバイトのみ</strong></td>
+          <td>「アルバイト50名中35名提出」（統計情報）</td>
+          <td>cron</td>
+        </tr>
+        <tr class="changed">
+          <td>3</td>
+          <td>締切前日</td>
+          <td><span class="badge badge-green">グループ</span></td>
+          <td><strong>アルバイトのみ</strong></td>
+          <td>未提出のアルバイトを名前付きで通知</td>
+          <td>cron</td>
+        </tr>
+        <tr>
+          <td>4</td>
+          <td>締切後</td>
+          <td><span class="badge badge-green">グループ</span></td>
+          <td>全員向け</td>
+          <td>「未提出の方はオーナー指示に従ってください」</td>
+          <td>cron</td>
+        </tr>
+        <tr>
+          <td>5</td>
+          <td>第2案承認後</td>
+          <td><span class="badge badge-green">グループ</span></td>
+          <td>全員向け</td>
+          <td>「シフトが確定しました。確認をお願いします」</td>
+          <td>API</td>
+        </tr>
+      </table>
+
+      <p>
+        <strong>補足:</strong> フェーズ2,
+        3でアルバイトのみを対象とする理由は、社員はNG入力のみで希望シフト提出が不要なため。
+      </p>
+
+      <h3>4.2 第1案承認通知（Issue #104）</h3>
+      <table>
+        <tr>
+          <th>タイミング</th>
+          <th>送信先</th>
+          <th>通知内容</th>
+          <th>トリガー</th>
+        </tr>
+        <tr>
+          <td>第1案承認時</td>
+          <td><span class="badge badge-green">グループ</span></td>
+          <td>
+            シフト希望入力開始のお知らせ<br />（社員: NG入力依頼 / アルバイト:
+            希望シフト提出依頼）
+          </td>
+          <td>API</td>
+        </tr>
+      </table>
+
+      <h3>4.3 第2案承認通知（フェーズ5）</h3>
+      <table>
+        <tr>
+          <th>タイミング</th>
+          <th>送信先</th>
+          <th>通知内容</th>
+          <th>トリガー</th>
+        </tr>
+        <tr>
+          <td>第2案承認時</td>
+          <td><span class="badge badge-green">グループ</span></td>
+          <td>「シフトが確定しました。LIFFアプリで確認してください」</td>
+          <td>API</td>
+        </tr>
+      </table>
+
+      <!-- API設計 -->
+      <h2>5. API設計</h2>
+
+      <h3>5.1 LIFF Backend が提供するAPI（新規作成）</h3>
+
+      <div class="api-spec">
+        <h4>
+          <span class="http-method http-post">POST</span>
+          /api/notification/first-plan-approved
+        </h4>
+        <p>第1案承認時にshift-scheduler-aiから呼び出される</p>
+        <table>
+          <tr>
+            <th width="20%">項目</th>
+            <th>内容</th>
+          </tr>
+          <tr>
+            <td>呼び出し元</td>
+            <td>shift-scheduler-ai（routes/shifts.js の approve-first）</td>
+          </tr>
+          <tr>
+            <td>Request Body</td>
+            <td>
+              <pre>
+{
+  "tenant_id": 3,
+  "store_id": 1,
+  "plan_id": 123,
+  "year": 2025,
+  "month": 1
+}</pre
+              >
+            </td>
+          </tr>
+          <tr>
+            <td>Response</td>
+            <td>
+              <pre>
+{
+  "success": true,
+  "message": "Notification sent to group"
+}</pre
+              >
+            </td>
+          </tr>
+          <tr>
+            <td>処理内容</td>
+            <td>該当テナントのLINEグループに第1案承認通知を送信</td>
+          </tr>
+        </table>
+      </div>
+
+      <div class="api-spec">
+        <h4>
+          <span class="http-method http-post">POST</span>
+          /api/notification/second-plan-approved
+        </h4>
+        <p>第2案承認時にshift-scheduler-aiから呼び出される</p>
+        <table>
+          <tr>
+            <th width="20%">項目</th>
+            <th>内容</th>
+          </tr>
+          <tr>
+            <td>呼び出し元</td>
+            <td>shift-scheduler-ai（routes/shifts.js の approve-second）</td>
+          </tr>
+          <tr>
+            <td>Request Body</td>
+            <td>
+              <pre>
+{
+  "tenant_id": 3,
+  "store_id": 1,
+  "plan_id": 456,
+  "year": 2025,
+  "month": 1
+}</pre
+              >
+            </td>
+          </tr>
+          <tr>
+            <td>Response</td>
+            <td>
+              <pre>
+{
+  "success": true,
+  "message": "Notification sent to group"
+}</pre
+              >
+            </td>
+          </tr>
+          <tr>
+            <td>処理内容</td>
+            <td>該当テナントのLINEグループにシフト確定通知を送信</td>
+          </tr>
+        </table>
+      </div>
+
+      <div class="api-spec">
+        <h4>
+          <span class="http-method http-post">POST</span> /api/webhook/line
+        </h4>
+        <p>LINE Webhook受信（グループID確認用）</p>
+        <table>
+          <tr>
+            <th width="20%">項目</th>
+            <th>内容</th>
+          </tr>
+          <tr>
+            <td>呼び出し元</td>
+            <td>LINE Platform（Botがグループ参加時）</td>
+          </tr>
+          <tr>
+            <td>処理内容</td>
+            <td>グループIDをログ出力（設定ファイルへの手動追加用）</td>
+          </tr>
+        </table>
+      </div>
+
+      <h3>5.2 shift-scheduler-ai の修正箇所（実装済み）</h3>
+
+      <div class="api-spec">
+        <h4>修正ファイル: routes/shifts.js</h4>
+        <p>承認処理後にLIFF Backend APIを呼び出す</p>
+
+        <h4>approve-first エンドポイント（1126〜1141行目）:</h4>
+        <pre>
+// LINE通知を送信（第1案承認）
+if (process.env.LIFF_BACKEND_URL) {
+  try {
+    await axios.post(`${process.env.LIFF_BACKEND_URL}/api/notification/first-plan-approved`, {
+      tenant_id: tenant_id,
+      store_id: plan.store_id,
+      plan_id: plan_id,
+      year: plan.plan_year,
+      month: plan.plan_month
+    });
+    console.log('LINE notification sent for first plan approval');
+  } catch (notifyError) {
+    // 通知失敗は承認処理に影響させない（ログのみ）
+    console.error('Failed to send LINE notification:', notifyError.message);
+  }
+}</pre
+        >
+
+        <h4>
+          ステータス更新エンドポイント PUT
+          /plans/:plan_id/status（2742〜2757行目）:
+        </h4>
+        <p>
+          <strong>注意:</strong>
+          第2案承認はこのエンドポイントで処理される（plan_type='SECOND'かつstatus='APPROVED'時）
+        </p>
+        <pre>
+// 第2案がAPPROVEDになった場合、LINE通知を送信（シフト確定）
+if (status === 'APPROVED' && plan.plan_type === 'SECOND' && process.env.LIFF_BACKEND_URL) {
+  try {
+    await axios.post(`${process.env.LIFF_BACKEND_URL}/api/notification/second-plan-approved`, {
+      tenant_id: plan.tenant_id,
+      store_id: plan.store_id,
+      plan_id: parseInt(plan_id),
+      year: plan.plan_year,
+      month: plan.plan_month
+    });
+    console.log('LINE notification sent for second plan approval (shift finalized)');
+  } catch (notifyError) {
+    // 通知失敗は承認処理に影響させない（ログのみ）
+    console.error('Failed to send LINE notification:', notifyError.message);
+  }
+}</pre
+        >
+      </div>
+
+      <!-- 通知フロー -->
+      <h2>6. 通知フロー図</h2>
+
+      <h3>6.1 第1案承認通知フロー</h3>
+      <div class="flow-diagram">
+        <div class="flow-step">オーナーが<br />第1案承認</div>
+        <span class="flow-arrow">→</span>
+        <div class="flow-step">shifts.js<br />approve-first</div>
+        <span class="flow-arrow">→</span>
+        <div class="flow-step">
+          LIFF API呼び出し<br /><small
+            >/api/notification/first-plan-approved</small
+          >
+        </div>
+        <span class="flow-arrow">→</span>
+        <div class="flow-step">LINE<br />グループ送信</div>
+      </div>
+
+      <h3>6.2 第2案承認通知フロー（フェーズ5）</h3>
+      <div class="flow-diagram">
+        <div class="flow-step">オーナーが<br />第2案承認</div>
+        <span class="flow-arrow">→</span>
+        <div class="flow-step">
+          shifts.js<br /><small>PUT /plans/:id/status</small>
+        </div>
+        <span class="flow-arrow">→</span>
+        <div class="flow-step">plan_type=SECOND<br />status=APPROVED判定</div>
+        <span class="flow-arrow">→</span>
+        <div class="flow-step">
+          LIFF API呼び出し<br /><small
+            >/api/notification/second-plan-approved</small
+          >
+        </div>
+        <span class="flow-arrow">→</span>
+        <div class="flow-step">LINE<br />グループ送信</div>
+      </div>
+
+      <h3>6.3 リマインド通知フロー（フェーズ1〜4）</h3>
+      <div class="flow-diagram">
+        <div class="flow-step">cron実行<br /><small>（毎日9:00）</small></div>
+        <span class="flow-arrow">→</span>
+        <div
+          class="flow-step"
+          style="background: #fff3cd; border-color: #ffc107"
+        >
+          締切設定取得<br /><small>（DBから動的取得）</small>
+        </div>
+        <span class="flow-arrow">→</span>
+        <div class="flow-step">
+          フェーズ判定<br /><small>（残り日数）</small>
+        </div>
+        <span class="flow-arrow">→</span>
+        <div class="flow-step">
+          提出状況取得<br /><small>（アルバイトのみ）</small>
+        </div>
+        <span class="flow-arrow">→</span>
+        <div class="flow-step">LINE<br />グループ送信</div>
+      </div>
+      <p style="font-size: 0.9rem; color: #666; margin-top: 10px">
+        ※ 締切設定は
+        <code>core.shift_deadline_settings</code>
+        テーブルからPART_TIMEの設定を取得
+      </p>
+
+      <!-- 新規作成ファイル一覧 -->
+      <h2>7. 新規作成・修正ファイル一覧</h2>
+
+      <h3>7.1 shift-scheduler-ai-liff/backend</h3>
+      <div class="file-tree">
+        <span class="existing">shift-scheduler-ai-liff/backend/</span>
+        <span class="existing">├── src/</span>
+        <span class="existing">│ ├── config/</span>
+        <span class="existing">│ │ └── database.js # 既存</span>
+        <span class="new"
+          >│ │ └── line-notification.json #
+          【新規】グループID・リマインド設定</span
+        >
+        <span class="new">│ ├── routes/</span>
+        <span class="new">│ │ ├── webhook.js # 【新規】LINE Webhook受信</span>
+        <span class="new">│ │ └── notification.js # 【新規】通知API</span>
+        <span class="existing">│ ├── services/</span>
+        <span class="modify"
+          >│ │ ├── reminderService.js #
+          【修正】5フェーズ対応、グループ送信</span
+        >
+        <span class="new"
+          >│ │ ├── lineService.js # 【新規】LINE送信（個人/グループ）</span
+        >
+        <span class="new"
+          >│ │ └── submissionService.js #
+          【新規】提出状況集計（アルバイトのみ）</span
+        >
+        <span class="existing">│ ├── jobs/</span>
+        <span class="existing"
+          >│ │ └── shiftReminder.js # 既存（テスト用）</span
+        >
+        <span class="modify">│ └── index.js # 【修正】ルート追加</span>
+        <span class="modify">├── .env # 【修正】LINE_CHANNEL_SECRET追加</span>
+        <span class="existing"
+          >└── package.json # 既存（依存パッケージ追加済み）</span
+        >
+      </div>
+
+      <table>
+        <tr>
+          <th>ファイル</th>
+          <th>状態</th>
+          <th>説明</th>
+        </tr>
+        <tr class="new-file">
+          <td><code>config/line-notification.json</code></td>
+          <td><span class="badge badge-new">新規</span></td>
+          <td>グループID、リマインド日数、メッセージテンプレート</td>
+        </tr>
+        <tr class="new-file">
+          <td><code>routes/webhook.js</code></td>
+          <td><span class="badge badge-new">新規</span></td>
+          <td>LINEからのWebhook受信（グループID確認用）</td>
+        </tr>
+        <tr class="new-file">
+          <td><code>routes/notification.js</code></td>
+          <td><span class="badge badge-new">新規</span></td>
+          <td>承認通知API（first-plan-approved, second-plan-approved）</td>
+        </tr>
+        <tr class="new-file">
+          <td><code>services/lineService.js</code></td>
+          <td><span class="badge badge-new">新規</span></td>
+          <td>LINE送信処理（個人・グループ対応）</td>
+        </tr>
+        <tr class="new-file">
+          <td><code>services/submissionService.js</code></td>
+          <td><span class="badge badge-new">新規</span></td>
+          <td>アルバイトのシフト提出状況を集計</td>
+        </tr>
+        <tr>
+          <td><code>services/reminderService.js</code></td>
+          <td><span class="badge badge-modify">修正</span></td>
+          <td>5フェーズ対応、グループ送信に変更</td>
+        </tr>
+        <tr>
+          <td><code>index.js</code></td>
+          <td><span class="badge badge-modify">修正</span></td>
+          <td>Webhookルート、通知APIルートの追加</td>
+        </tr>
+        <tr>
+          <td><code>.env</code></td>
+          <td><span class="badge badge-modify">修正</span></td>
+          <td>LINE_CHANNEL_SECRET 追加</td>
+        </tr>
+      </table>
+
+      <h3>7.2 shift-scheduler-ai/backend（軽微な修正）</h3>
+      <div class="file-tree">
+        <span class="existing">shift-scheduler-ai/backend/</span>
+        <span class="existing">├── src/</span>
+        <span class="existing">│ └── routes/</span>
+        <span class="modify"
+          >│ └── shifts.js # 【修正】承認時にLIFF API呼び出し追加</span
+        >
+        <span class="modify">└── .env # 【修正】LIFF_BACKEND_URL追加</span>
+      </div>
+
+      <table>
+        <tr>
+          <th>ファイル</th>
+          <th>状態</th>
+          <th>変更内容</th>
+        </tr>
+        <tr>
+          <td><code>routes/shifts.js</code></td>
+          <td><span class="badge badge-modify">修正</span></td>
+          <td>approve-first, approve-second にAPI呼び出し追加（各約10行）</td>
+        </tr>
+        <tr>
+          <td><code>.env</code></td>
+          <td><span class="badge badge-modify">修正</span></td>
+          <td><code>LIFF_BACKEND_URL</code> 追加</td>
+        </tr>
+      </table>
+
+      <!-- 環境変数 -->
+      <h2>8. 環境変数</h2>
+
+      <h3>8.1 shift-scheduler-ai-liff/backend</h3>
+      <table>
+        <tr>
+          <th>変数名</th>
+          <th>説明</th>
+          <th>状態</th>
+        </tr>
+        <tr>
+          <td><code>LINE_CHANNEL_ACCESS_TOKEN</code></td>
+          <td>LINE Messaging APIトークン</td>
+          <td>既存</td>
+        </tr>
+        <tr>
+          <td><code>LINE_CHANNEL_SECRET</code></td>
+          <td>Webhook署名検証用</td>
+          <td><span class="badge badge-new">追加</span></td>
+        </tr>
+        <tr>
+          <td><code>DATABASE_URL</code></td>
+          <td>PostgreSQL接続URL</td>
+          <td>既存</td>
+        </tr>
+        <tr>
+          <td><code>TENANT_ID</code></td>
+          <td>対象テナントID</td>
+          <td>既存</td>
+        </tr>
+        <tr>
+          <td><code>LIFF_ID</code></td>
+          <td>LIFF App ID（メッセージ内URL用）</td>
+          <td>既存</td>
+        </tr>
+        <tr>
+          <td><code>NOTIFICATION_ENABLED</code></td>
+          <td>通知有効/無効フラグ（テスト時にfalse）</td>
+          <td><span class="badge badge-new">追加</span></td>
+        </tr>
+      </table>
+
+      <h3>8.2 shift-scheduler-ai/backend</h3>
+      <table>
+        <tr>
+          <th>変数名</th>
+          <th>説明</th>
+          <th>状態</th>
+        </tr>
+        <tr>
+          <td><code>LIFF_BACKEND_URL</code></td>
+          <td>LIFF BackendのURL（LINE通知送信用）</td>
+          <td><span class="badge badge-new">追加</span></td>
+        </tr>
+      </table>
+
+      <h4>LIFF_BACKEND_URL 環境別設定値</h4>
+      <table>
+        <tr>
+          <th>環境</th>
+          <th>URL</th>
+        </tr>
+        <tr>
+          <td>LOCAL</td>
+          <td><code>http://localhost:3001</code></td>
+        </tr>
+        <tr>
+          <td>STG</td>
+          <td>
+            <code
+              >https://shift-scheduler-ai-liff-backend-staging-staging.up.railway.app</code
+            >
+          </td>
+        </tr>
+        <tr>
+          <td>PRD</td>
+          <td>
+            <code
+              >https://shift-scheduler-ai-liff-production.up.railway.app</code
+            >
+          </td>
+        </tr>
+      </table>
+      <p>
+        <strong>設定場所:</strong>
+        Railway環境変数（STG/PRD）、.envファイル（LOCAL）
+      </p>
+
+      <!-- 締切設定（DB） -->
+      <h2>9. 締切設定（データベース）</h2>
+
+      <div class="card changed">
+        <h3>締切日の取得元</h3>
+        <p>
+          締切日は
+          <code>core.shift_deadline_settings</code>
+          テーブルから<strong>アルバイト（PART_TIME）</strong>の設定を動的に取得します。
+        </p>
+
+        <h4>使用するDBテーブル</h4>
+        <pre>
+SELECT deadline_day, deadline_time, is_enabled
+FROM core.shift_deadline_settings
+WHERE tenant_id = $1 AND employment_type = 'PART_TIME'</pre
+        >
+
+        <table>
+          <tr>
+            <th>カラム</th>
+            <th>型</th>
+            <th>説明</th>
+            <th>例</th>
+          </tr>
+          <tr>
+            <td>deadline_day</td>
+            <td>INTEGER</td>
+            <td>締切日（1-31）</td>
+            <td>10</td>
+          </tr>
+          <tr>
+            <td>deadline_time</td>
+            <td>VARCHAR</td>
+            <td>締切時刻（HH:MM形式）</td>
+            <td>23:59</td>
+          </tr>
+          <tr>
+            <td>is_enabled</td>
+            <td>BOOLEAN</td>
+            <td>有効フラグ</td>
+            <td>true</td>
+          </tr>
+        </table>
+
+        <h4>フォールバック</h4>
+        <p>DB取得に失敗した場合、デフォルト値を使用:</p>
+        <ul>
+          <li>deadline_day: 10</li>
+          <li>deadline_time: 23:59</li>
+          <li>is_enabled: true</li>
+        </ul>
+      </div>
+
+      <!-- 設定ファイル -->
+      <h2>10. 設定ファイル構造</h2>
+
+      <p>
+        グループID、リマインドフェーズ、メッセージテンプレートなどは設定ファイルで管理します。<br />
+        <strong
+          >※ 締切日はDBから取得するため、settings.deadlineDay
+          はフォールバック専用です。</strong
+        >
+      </p>
+
+      <pre>
+// config/line-notification.json
+{
+  "groups": {
+    "tenant_3": {
+      "groupId": "Cxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "name": "Stand Banh Mi スタッフ"
+    }
+  },
+  "reminders": [
+    { "daysBefore": 7, "type": "anonymous", "phase": 1 },
+    { "daysBefore": 3, "type": "stats", "phase": 2, "targetOnly": "partTime" },
+    { "daysBefore": 1, "type": "named", "phase": 3, "targetOnly": "partTime" },
+    { "daysBefore": 0, "type": "deadline_passed", "phase": 4 },
+    { "trigger": "second_plan_approved", "type": "confirmed", "phase": 5 }
+  ],
+  "cronSchedule": "0 9 * * *",
+  "settings": {
+    "deadlineDay": 10,        // ※ フォールバック専用（通常はDBから取得）
+    "timezone": "Asia/Tokyo",
+    "enabled": true
+  }
+}</pre
+      >
+
+      <!-- 実装ステップ -->
+      <h2>11. 実装ステップ</h2>
+      <table>
+        <tr>
+          <th>Step</th>
+          <th>内容</th>
+          <th>対象</th>
+          <th>状態</th>
+        </tr>
+        <tr class="highlight">
+          <td>1</td>
+          <td>設定ファイル作成（line-notification.json）</td>
+          <td>LIFF backend</td>
+          <td><span class="badge badge-green">完了</span></td>
+        </tr>
+        <tr class="highlight">
+          <td>2</td>
+          <td>LINE送信サービス作成（lineService.js）</td>
+          <td>LIFF backend</td>
+          <td><span class="badge badge-green">完了</span></td>
+        </tr>
+        <tr class="highlight">
+          <td>3</td>
+          <td>Webhookエンドポイント作成（webhook.js）</td>
+          <td>LIFF backend</td>
+          <td><span class="badge badge-green">完了</span></td>
+        </tr>
+        <tr class="highlight">
+          <td>4</td>
+          <td>通知APIエンドポイント作成（notification.js）</td>
+          <td>LIFF backend</td>
+          <td><span class="badge badge-green">完了</span></td>
+        </tr>
+        <tr class="highlight">
+          <td>5</td>
+          <td>提出状況集計サービス作成（submissionService.js）</td>
+          <td>LIFF backend</td>
+          <td><span class="badge badge-green">完了</span></td>
+        </tr>
+        <tr class="highlight">
+          <td>6</td>
+          <td>リマインドサービス拡張（5フェーズ対応・DB締切取得）</td>
+          <td>LIFF backend</td>
+          <td><span class="badge badge-green">完了</span></td>
+        </tr>
+        <tr class="highlight">
+          <td>7</td>
+          <td>index.jsにルート追加</td>
+          <td>LIFF backend</td>
+          <td><span class="badge badge-green">完了</span></td>
+        </tr>
+        <tr class="highlight">
+          <td>8</td>
+          <td>shifts.jsに通知API呼び出し追加</td>
+          <td>shift-scheduler-ai</td>
+          <td><span class="badge badge-green">完了</span></td>
+        </tr>
+        <tr class="warning">
+          <td>9</td>
+          <td>Railway環境変数設定（LIFF_BACKEND_URL）</td>
+          <td>shift-scheduler-ai</td>
+          <td><span class="badge badge-yellow">STG設定待ち</span></td>
+        </tr>
+        <tr class="warning">
+          <td>10</td>
+          <td>Railway環境変数設定（NOTIFICATION_ENABLED）</td>
+          <td>shift-scheduler-ai-liff</td>
+          <td><span class="badge badge-yellow">STG設定待ち</span></td>
+        </tr>
+        <tr class="warning">
+          <td>11</td>
+          <td>STGテスト・動作確認</td>
+          <td>全体</td>
+          <td><span class="badge badge-yellow">未着手</span></td>
+        </tr>
+      </table>
+
+      <!-- メッセージテンプレート -->
+      <h2>12. メッセージテンプレート</h2>
+
+      <h3>フェーズ1: 締切7日前（匿名）</h3>
+      <pre>
+【シフト希望入力のお願い】
+
+{targetMonth}月のシフト希望入力がまだの方は
+{deadline}までに入力をお願いします。
+
+入力はこちら: {liffUrl}</pre
+      >
+
+      <h3>フェーズ2: 締切3日前（統計・アルバイトのみ）</h3>
+      <pre>
+【シフト希望提出状況】
+
+{targetMonth}月分: アルバイト {totalCount}名中 {submittedCount}名 提出済み
+未提出: {unsubmittedCount}名
+
+{deadline}までにご提出ください。
+入力はこちら: {liffUrl}</pre
+      >
+
+      <h3>フェーズ3: 締切前日（名前付き・アルバイトのみ）</h3>
+      <pre>
+【シフト希望 締切前日】
+
+{targetMonth}月分の未提出者（アルバイト）:
+{unsubmittedNames}
+
+明日 {deadline} が締切です。
+入力はこちら: {liffUrl}</pre
+      >
+
+      <h3>フェーズ4: 締切後</h3>
+      <pre>
+【シフト希望 締切通知】
+
+{targetMonth}月分のシフト希望締切を過ぎました。
+
+未提出の方はオーナーの指示に従ってください。</pre
+      >
+
+      <h3>第1案承認通知</h3>
+      <pre>
+【{targetMonth}月シフト希望入力開始】
+
+第1案が承認されました。
+シフト希望の入力が可能になりました。
+
+締切: {deadline}
+入力はこちら: {liffUrl}</pre
+      >
+
+      <h3>フェーズ5: 第2案承認後</h3>
+      <pre>
+【シフト確定のお知らせ】
+
+{targetMonth}月のシフトが確定しました。</pre
+      >
+
+      <!-- テスト用エンドポイント -->
+      <h2>13. テスト用エンドポイント</h2>
+
+      <div class="api-spec">
+        <h4>
+          <span class="http-method http-post">POST</span> /api/send-reminder
+        </h4>
+        <p>指定した年月のリマインド通知を手動送信（フェーズ1〜4のテスト用）</p>
+        <table>
+          <tr>
+            <th width="20%">項目</th>
+            <th>内容</th>
+          </tr>
+          <tr>
+            <td>Request Body</td>
+            <td>
+              <pre>
+{
+  "year": 2026,
+  "month": 1
+}</pre
+              >
+            </td>
+          </tr>
+          <tr>
+            <td>Response</td>
+            <td>
+              <pre>
+{
+  "success": true,
+  "message": "Reminder sent",
+  "notified": true,
+  "phase": 1,
+  "type": "anonymous"
+}</pre
+              >
+            </td>
+          </tr>
+          <tr>
+            <td>処理内容</td>
+            <td>
+              指定月の締切との差分からフェーズを判定し、該当フェーズの通知を送信
+            </td>
+          </tr>
+        </table>
+      </div>
+
+      <div class="api-spec">
+        <h4>
+          <span class="http-method http-post">POST</span>
+          /api/send-auto-reminder
+        </h4>
+        <p>自動計算（来月分）でリマインド通知を送信</p>
+        <table>
+          <tr>
+            <th width="20%">項目</th>
+            <th>内容</th>
+          </tr>
+          <tr>
+            <td>Request Body</td>
+            <td>なし</td>
+          </tr>
+          <tr>
+            <td>処理内容</td>
+            <td>現在日付から来月を計算し、リマインド通知を実行</td>
+          </tr>
+        </table>
+      </div>
+
+      <div class="api-spec">
+        <h4>
+          <span class="http-method http-post">POST</span> /api/notification/test
+        </h4>
+        <p>任意のメッセージをグループに送信（テスト用）</p>
+        <table>
+          <tr>
+            <th width="20%">項目</th>
+            <th>内容</th>
+          </tr>
+          <tr>
+            <td>Request Body</td>
+            <td>
+              <pre>
+{
+  "tenant_id": 3,
+  "message": "テストメッセージ"
+}</pre
+              >
+            </td>
+          </tr>
+          <tr>
+            <td>処理内容</td>
+            <td>指定テナントのグループに任意のメッセージを送信</td>
+          </tr>
+        </table>
+      </div>
+
+      <h3>フェーズ別テスト方法</h3>
+      <table>
+        <tr>
+          <th>フェーズ</th>
+          <th>テスト条件</th>
+          <th>方法</th>
+        </tr>
+        <tr>
+          <td>1</td>
+          <td>締切7日前</td>
+          <td>
+            DBの締切日を「今日から7日後」に設定 →
+            <code>/api/send-auto-reminder</code> 実行
+          </td>
+        </tr>
+        <tr>
+          <td>2</td>
+          <td>締切3日前</td>
+          <td>
+            DBの締切日を「今日から3日後」に設定 →
+            <code>/api/send-auto-reminder</code> 実行
+          </td>
+        </tr>
+        <tr>
+          <td>3</td>
+          <td>締切前日</td>
+          <td>
+            DBの締切日を「今日から1日後」に設定 →
+            <code>/api/send-auto-reminder</code> 実行
+          </td>
+        </tr>
+        <tr>
+          <td>4</td>
+          <td>締切後</td>
+          <td>
+            DBの締切日を「今日以前」に設定 →
+            <code>/api/send-auto-reminder</code> 実行
+          </td>
+        </tr>
+        <tr>
+          <td>5</td>
+          <td>第2案承認時</td>
+          <td>管理画面から第2案をAPPROVED → 自動送信</td>
+        </tr>
+      </table>
+
+      <!-- 通知の停止・再開 -->
+      <h2>14. 通知の停止・再開</h2>
+
+      <table>
+        <tr>
+          <th>方法</th>
+          <th>範囲</th>
+          <th>設定場所</th>
+          <th>反映タイミング</th>
+        </tr>
+        <tr>
+          <td>環境変数</td>
+          <td>全体</td>
+          <td><code>NOTIFICATION_ENABLED=false</code></td>
+          <td>サーバー再起動後</td>
+        </tr>
+        <tr>
+          <td>DB設定</td>
+          <td>テナント単位</td>
+          <td><code>core.shift_deadline_settings.is_enabled</code></td>
+          <td>即時（次回cron実行時）</td>
+        </tr>
+      </table>
+
+      <pre>
+-- テナント3の通知を停止
+UPDATE core.shift_deadline_settings
+SET is_enabled = false
+WHERE tenant_id = 3 AND employment_type = 'PART_TIME';
+
+-- 再開
+UPDATE core.shift_deadline_settings
+SET is_enabled = true
+WHERE tenant_id = 3 AND employment_type = 'PART_TIME';</pre
+      >
+
+      <!-- 今後の拡張 -->
+      <h2>15. 今後の拡張（将来検討）</h2>
+      <ul>
+        <li>テナント数増加時にグループID設定をDB管理へ移行</li>
+        <li>管理画面からの通知設定変更UI</li>
+        <li>通知ログのDB保存・履歴確認機能</li>
+        <li>ユーザーからの返信対応（チャットボット）</li>
+        <li>テナント単位の通知ON/OFF管理UI</li>
+      </ul>
+
+      <div
+        class="card"
+        style="margin-top: 40px; text-align: center; color: #666"
+      >
+        <p>End of Document</p>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- 第1案承認時のシフト希望入力開始通知を実装
- 第2案承認時のシフト確定通知を実装
- リマインド通知（フェーズ1〜4: 締切7日前/3日前/前日/締切後）を実装
- 締切日をDBから動的取得（core.shift_deadline_settings）
- 通知ON/OFF制御（NOTIFICATION_ENABLED環境変数）

## 関連Issue
- #130 リマインド・締切後通知
- #104 第1案/第2案承認通知

## 変更ファイル
### 新規追加
- `backend/src/config/line-notification.json` - 通知設定
- `backend/src/routes/notification.js` - 通知API
- `backend/src/routes/webhook.js` - LINE Webhook
- `backend/src/services/lineService.js` - LINE送信サービス
- `backend/src/services/submissionService.js` - 提出状況集計
- `docs/design-docs/line-notification-design-v2.html` - 設計書v2.3

### 修正
- `backend/src/index.js` - ルート追加
- `backend/src/services/reminderService.js` - 5フェーズ対応

## Test plan
- [ ] NOTIFICATION_ENABLED=false でメッセージがスキップされることを確認
- [ ] テスト用エンドポイント `/api/notification/test` で通知送信を確認
- [ ] 第1案承認時に通知が送信されることを確認（shift-scheduler-ai側の変更後）
- [ ] 第2案承認時に通知が送信されることを確認（shift-scheduler-ai側の変更後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)