### PR TITLE
fix: LINE通知の日数計算修正と対象月の初期表示を変更

### DIFF
--- a/backend/src/config/line-notification.json
+++ b/backend/src/config/line-notification.json
@@ -50,7 +50,7 @@
     "firstPlanApproved": "【{targetMonth}月シフト希望入力開始】\n\n第1案が承認されました。\nシフト希望の入力が可能になりました。\n\n締切: {deadline}\n入力はこちら: {liffUrl}",
     "secondPlanApproved": "【シフト確定のお知らせ】\n\n{targetMonth}月のシフトが確定しました。"
   },
-  "cronSchedule": "0 9 * * *",
+  "cronSchedule": "0 0 * * *",
   "settings": {
     "deadlineDay": 10,
     "timezone": "Asia/Tokyo",

--- a/backend/src/services/reminderService.js
+++ b/backend/src/services/reminderService.js
@@ -37,22 +37,23 @@ export function getDaysUntilDeadline(
     deadlineYear--;
   }
 
-  // 締切時刻をパース
-  const [hour, minute] = deadlineTime.split(':').map(Number);
-
+  // 締切日（時刻は0:00で統一して日付のみで計算）
   const deadline = new Date(
     deadlineYear,
     deadlineMonth - 1,
     deadlineDay,
-    hour,
-    minute,
-    59
+    0,
+    0,
+    0,
+    0
   );
+
+  // 今日（時刻は0:00で統一）
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
   const diffTime = deadline.getTime() - today.getTime();
-  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  const diffDays = Math.round(diffTime / (1000 * 60 * 60 * 24));
 
   return diffDays;
 }

--- a/index.html
+++ b/index.html
@@ -489,6 +489,12 @@
       // MVP: パターン入力を廃止 (Issue #103) - 時刻入力のみに固定
       let mode = 'time'; // "pattern" or "time"
       let cur = new Date();
+      const currentDay = cur.getDate();
+      if (currentDay <= 20) {
+        cur.setMonth(cur.getMonth() + 1); // 来月
+      } else {
+        cur.setMonth(cur.getMonth() + 2); // 再来月
+      }
       cur.setDate(1); // 月の先頭
       let selected = new Map(); // key=YYYY-MM-DD, val={type:'part'|'emp', start,end,label}
       let currentPattern = PATTERNS[0];


### PR DESCRIPTION
## Summary
- LINE通知の日数計算で1日ズレていた問題を修正 (Issue shift-scheduler-ai#216)
- CRONスケジュールをJST対応に修正 (UTC 0:00 = JST 9:00)
- LIFFの対象月初期表示を管理画面と同じ「20日ルール」に変更 (Issue shift-scheduler-ai#194)

## 変更内容

### 1. 日数計算の1日ズレ修正
**ファイル:** `backend/src/services/reminderService.js`
- 締切日までの残り日数計算で、時刻を0:00で統一
- `Math.ceil` → `Math.round` に変更
- 例: 12/11→12/17 が7日ではなく6日と正しく計算される

### 2. CRONのJST対応
**ファイル:** `backend/src/config/line-notification.json`
- `"cronSchedule": "0 9 * * *"` → `"0 0 * * *"`
- UTC 0:00 = JST 9:00 で通知送信

### 3. LIFF対象月の初期表示変更
**ファイル:** `index.html`
- 管理画面と同じ「20日ルール」を導入
  - 20日以前 → 来月（現在月+1）
  - 21日以降 → 再来月（現在月+2）

## Test plan
- [ ] STGにデプロイ
- [ ] テストAPI実行: `curl -X POST https://shift-scheduler-ai-liff-backend-staging-staging.up.railway.app/api/send-auto-reminder`
- [ ] 「Days until deadline」の値が正しいか確認
- [ ] LIFFを開いて初期表示月が正しいか確認（今日12日なら1月が表示）

🤖 Generated with [Claude Code](https://claude.com/claude-code)