### PR TITLE
refactor: アルバイト判定をpayment_typeからemployment_codeに変更

### DIFF
--- a/backend/src/services/submissionService.js
+++ b/backend/src/services/submissionService.js
@@ -11,7 +11,7 @@ dotenv.config();
  * @returns {Promise<Object>} 提出状況の統計情報
  */
 export async function getPartTimeSubmissionStats(tenantId, year, month) {
-  // アルバイト（HOURLY）の総数を取得
+  // アルバイト（PART_TIME）の総数を取得
   const totalQuery = `
     SELECT COUNT(*) as total_count
     FROM hr.staff s
@@ -20,7 +20,7 @@ export async function getPartTimeSubmissionStats(tenantId, year, month) {
     WHERE s.tenant_id = $1
       AND s.is_active = true
       AND sla.is_active = true
-      AND et.payment_type = 'HOURLY'
+      AND et.employment_code = 'PART_TIME'
   `;
 
   // 提出済みアルバイトの数を取得（staff_monthly_submissionsテーブルを参照）
@@ -33,7 +33,7 @@ export async function getPartTimeSubmissionStats(tenantId, year, month) {
     WHERE s.tenant_id = $1
       AND s.is_active = true
       AND sla.is_active = true
-      AND et.payment_type = 'HOURLY'
+      AND et.employment_code = 'PART_TIME'
       AND sms.year = $2
       AND sms.month = $3
   `;
@@ -85,7 +85,7 @@ export async function getUnsubmittedPartTimeStaff(tenantId, year, month) {
     WHERE sla.tenant_id = $1
       AND sla.is_active = true
       AND s.is_active = true
-      AND et.payment_type = 'HOURLY'
+      AND et.employment_code = 'PART_TIME'
       AND NOT EXISTS (
         SELECT 1 FROM ops.staff_monthly_submissions sms
         WHERE sms.staff_id = s.staff_id
@@ -186,7 +186,7 @@ export async function getAllPartTimeStaffWithLineId(tenantId) {
     WHERE sla.tenant_id = $1
       AND sla.is_active = true
       AND s.is_active = true
-      AND et.payment_type = 'HOURLY'
+      AND et.employment_code = 'PART_TIME'
     ORDER BY s.name
   `;
 


### PR DESCRIPTION
## Summary
- アルバイト判定の条件を `payment_type = 'HOURLY'` から `employment_code = 'PART_TIME'` に変更
- 意味的に正しい判定方法に修正（時給制ではなく雇用形態で判断）
- 管理画面側との整合性を確保

## 変更内容
**ファイル:** `backend/src/services/submissionService.js`

4箇所のクエリで使用している条件を変更:
```sql
-- 修正前
AND et.payment_type = 'HOURLY'

-- 修正後
AND et.employment_code = 'PART_TIME'
```

## 影響
- 現状のデータでは挙動に変化なし（PART_TIMEのみがHOURLY）
- 将来的に時給制の別雇用形態が追加された場合のリスク回避

## Test plan
- [ ] STGにデプロイ
- [ ] `curl -X POST .../api/send-auto-reminder` でリマインド送信テスト
- [ ] 通知対象者が変わっていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)