### PR TITLE
fix: メッセージイベントでGroup IDをログ出力

### DIFF
--- a/backend/src/routes/webhook.js
+++ b/backend/src/routes/webhook.js
@@ -59,6 +59,10 @@ router.post('/line', async (req, res) => {
       // メッセージイベント（将来の拡張用）
       if (event.type === 'message') {
         console.log('💬 Message received from:', event.source.type);
+        // グループからのメッセージの場合、Group IDもログ出力
+        if (event.source.type === 'group') {
+          console.log('📍 Group ID:', event.source.groupId);
+        }
         // 現時点ではメッセージには応答しない
       }
     }


### PR DESCRIPTION
## Summary
グループからのメッセージ受信時にGroup IDをログ出力するように修正

## 背景
- `join`イベント（ボット招待時）でのGroup ID取得が安定しない問題 (shift-scheduler-ai#202)
- メッセージイベントでもGroup IDを取得できるようにして代替手段を確保

## 変更内容
**ファイル:** `backend/src/routes/webhook.js`

```javascript
// メッセージイベント
if (event.type === 'message') {
  console.log('💬 Message received from:', event.source.type);
  // グループからのメッセージの場合、Group IDもログ出力（追加）
  if (event.source.type === 'group') {
    console.log('📍 Group ID:', event.source.groupId);
  }
}
```

## 影響
- 既存の処理に影響なし（ログ出力追加のみ）
- 負荷・コスト増なし
- DBへの書き込みなし

## Test plan
- [x] ローカルでcurlテスト実施
- [x] `📍 Group ID: Ctest123456789` がログに出力されることを確認
- [ ] STGでグループにメッセージを送信し、Railwayログで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)