### PR TITLE
fix: 社員の出勤時刻表示を改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
       }
       /* 社員向け：第1案の出勤時刻表示 */
       .cell .shift-time {
-        font-size: 8px;
+        font-size: 7px;
         color: var(--green);
         font-weight: 600;
         white-space: nowrap;
@@ -1660,12 +1660,12 @@
           // 社員の場合：第1案の出勤日にマーカーと時刻を表示（選択は任意の日でOK）
           if (role === 'emp' && firstPlanWorkDays.includes(key)) {
             cell.classList.add('first-plan-day');
-            // 出勤時刻を表示
+            // 出勤時刻を表示（開始-終了形式）
             const shiftTime = firstPlanShiftTimes.get(key);
-            if (shiftTime && shiftTime.start) {
+            if (shiftTime && shiftTime.start && shiftTime.end) {
               const timeLabel = document.createElement('div');
               timeLabel.className = 'shift-time';
-              timeLabel.textContent = formatTime(shiftTime.start);
+              timeLabel.textContent = `${formatTime(shiftTime.start)}-${formatTime(shiftTime.end)}`;
               cell.appendChild(timeLabel);
             }
           }


### PR DESCRIPTION
## Summary
- 社員の第1案出勤時刻の表示を改善
- フォントサイズを8px→7pxに縮小してセル内に収まるように
- 開始時刻のみ→開始-終了形式に変更（例: 9-18, 10:30-19:30）

## Test plan
- [ ] 社員でログインし、第1案出勤日の時刻が「開始-終了」形式で表示されることを確認
- [ ] 10:30-19:30のような30分刻みの時刻も正しく表示されることを確認
- [ ] 時刻がセル内に収まっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)