### PR TITLE
fix: 出勤時刻表示サイズ縮小と説明文を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
       }
       /* 社員向け：第1案の出勤時刻表示 */
       .cell .shift-time {
-        font-size: 7px;
+        font-size: 6px;
         color: var(--green);
         font-weight: 600;
         white-space: nowrap;
@@ -1869,7 +1869,7 @@
 
         if (role === 'emp') {
           tip.innerHTML =
-            '赤い日が「休み希望」です。選択した日が休み希望として登録されます。';
+            '赤い日が「出勤不可日」です。選択した日が出勤不可日として登録されます。';
           block.style.display = 'none';
         } else {
           tip.innerHTML =


### PR DESCRIPTION
## Summary
- フォントサイズを7px→6pxに縮小（10:30-19:30が収まるように）
- カレンダー下の説明文「休み希望」→「出勤不可日」に変更

## Test plan
- [ ] 10:30-19:30のような長い時刻表示がセル内に収まることを確認
- [ ] カレンダー下の説明文が「出勤不可日」になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)