### PR TITLE
fix: 時刻表示の改善（マーカー位置・フォントサイズ）

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
       .cell.first-plan-day::before {
         content: '';
         position: absolute;
-        top: 2px;
+        bottom: 2px;
         right: 2px;
         width: 6px;
         height: 6px;
@@ -160,7 +160,7 @@
         color: #b91c1c;
       }
       .label {
-        font-size: 9px;
+        font-size: 6px;
         padding: 2px 4px;
         border-radius: 999px;
         white-space: nowrap;


### PR DESCRIPTION
## Summary
- 緑●マーカーを右上→右下に移動（時刻表示との重なり解消）
- アルバイトのラベルフォントサイズを9px→6pxに縮小（時刻が収まるように）

## Test plan
- [ ] 社員：緑●マーカーが右下に表示され、時刻と重ならないことを確認
- [ ] アルバイト：10:30-18:30のような時刻がセル内に収まることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)