### PR TITLE
fix: 社員の出勤予定日表示を緑枠に修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,17 +138,15 @@
         background: var(--red-weak);
         border-color: var(--red);
       }
-      /* 社員向け：第1案で出勤予定がある日（緑背景） */
+      /* 社員向け：第1案で出勤予定がある日（緑枠） */
       .cell.first-plan-day {
-        background: var(--green-weak);
-        border-color: var(--green);
+        border: 2px solid var(--green);
       }
       .cell.first-plan-day .shift-time {
-        background: var(--green);
-        color: #fff;
         font-size: 6px;
-        padding: 2px 4px;
-        border-radius: 999px;
+        color: var(--green);
+        font-weight: 600;
+        white-space: nowrap;
       }
       /* 選択時は赤で上書き */
       .cell.first-plan-day.em-selected {
@@ -156,8 +154,7 @@
         border-color: var(--red);
       }
       .cell.first-plan-day.em-selected .shift-time {
-        background: var(--red);
-        color: #fff;
+        color: #b91c1c;
       }
       .label {
         font-size: 6px;


### PR DESCRIPTION
## Summary
- 社員：緑背景→緑枠に変更
- 社員：時刻表示を元のスタイルに戻す（緑文字、1行表示）

## Test plan
- [ ] 社員：出勤予定日が緑枠で囲まれていることを確認
- [ ] 社員：時刻が緑文字で1行表示されることを確認
- [ ] 社員：選択時に赤背景に変わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)