### PR TITLE
feat: リマインド通知の改善

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -4,6 +4,7 @@ import cron from 'node-cron';
 import {
   sendAutoReminder,
   sendShiftReminders,
+  sendReminderByPhase,
 } from './services/reminderService.js';
 import webhookRouter from './routes/webhook.js';
 import notificationRouter from './routes/notification.js';
@@ -28,6 +29,7 @@ app.get('/', (req, res) => {
       webhook: '/api/webhook/line',
       notification: '/api/notification/*',
       sendReminder: '/api/send-reminder',
+      sendReminderPhase: '/api/send-reminder-phase',
     },
   });
 });
@@ -85,12 +87,59 @@ app.post('/api/send-auto-reminder', async (req, res) => {
   }
 });
 
+// フェーズを指定してリマインダーを送信（手動送信用）
+app.post('/api/send-reminder-phase', async (req, res) => {
+  try {
+    const { year, month, phase } = req.body;
+
+    if (!year || !month || !phase) {
+      return res.status(400).json({
+        success: false,
+        error: 'year, month, and phase are required',
+        usage: {
+          year: 'number (e.g., 2026)',
+          month: 'number (1-12)',
+          phase: 'number (1=7日前, 2=3日前, 3=1日前, 4=締切後)',
+        },
+      });
+    }
+
+    const phaseNumber = parseInt(phase, 10);
+    if (phaseNumber < 1 || phaseNumber > 4) {
+      return res.status(400).json({
+        success: false,
+        error: 'phase must be 1, 2, 3, or 4',
+        phases: {
+          1: '7日前リマインド（匿名）',
+          2: '3日前リマインド（統計付き）',
+          3: '1日前リマインド（名前入り）',
+          4: '締切後通知',
+        },
+      });
+    }
+
+    const result = await sendReminderByPhase(year, month, phaseNumber);
+
+    res.json({
+      success: true,
+      message: `Phase ${phaseNumber} reminder sent for ${year}/${month}`,
+      ...result,
+    });
+  } catch (error) {
+    console.error('Error sending phase reminder:', error);
+    res.status(500).json({
+      success: false,
+      error: error.message,
+    });
+  }
+});
+
 // ===== Cronジョブ設定 =====
 
 const config = getNotificationConfig();
 const cronSchedule = config.cronSchedule || '0 9 * * *';
 
-// 毎日定時にリマインド通知をチェック
+// 毎日定時にリマインド通知をチェック（フェーズ4のみ自動送信、フェーズ1~3は手動）
 cron.schedule(cronSchedule, async () => {
   console.log('⏰ Cron job triggered at', new Date().toISOString());
 
@@ -110,6 +159,7 @@ app.listen(PORT, () => {
   console.log(
     `📅 Cron schedule: ${cronSchedule} (${config.settings.timezone})`
   );
+  console.log('📋 Cron behavior: Phase 4 only (Phase 1-3 is manual)');
   console.log(
     `📵 Notification enabled: ${process.env.NOTIFICATION_ENABLED !== 'false'}`
   );
@@ -120,7 +170,12 @@ app.listen(PORT, () => {
   console.log('  POST /api/notification/first-plan-approved');
   console.log('  POST /api/notification/second-plan-approved');
   console.log('  POST /api/notification/test      - Test notification');
-  console.log('  POST /api/send-reminder          - Manual reminder');
+  console.log(
+    '  POST /api/send-reminder          - Manual reminder (day-based)'
+  );
   console.log('  POST /api/send-auto-reminder     - Auto reminder');
+  console.log(
+    '  POST /api/send-reminder-phase    - Manual reminder (phase 1-4)'
+  );
   console.log('===========================================');
 });

--- a/backend/src/routes/notification.js
+++ b/backend/src/routes/notification.js
@@ -101,12 +101,17 @@ router.post('/first-plan-approved', async (req, res) => {
     const deadlineSettings = await getPartTimeDeadlineSettings(tenant_id);
     console.log('📋 Deadline settings from DB:', deadlineSettings);
 
-    // メッセージ作成（DBの締切日を使用）
+    // メッセージ作成（DBの締切日・締切時刻を使用）
     const config = getNotificationConfig();
     const template = config.approvalMessages.firstPlanApproved;
     const message = formatMessage(template, {
       targetMonth: month,
-      deadline: getDeadlineString(year, month, deadlineSettings.deadline_day),
+      deadline: getDeadlineString(
+        year,
+        month,
+        deadlineSettings.deadline_day,
+        deadlineSettings.deadline_time
+      ),
       liffUrl: getLiffUrl(),
     });
 

--- a/backend/src/services/lineService.js
+++ b/backend/src/services/lineService.js
@@ -135,12 +135,12 @@ export function formatMessage(template, variables) {
 }
 
 /**
- * LIFF URLを生成
- * @returns {string} LIFF URL
+ * アプリURLを取得
+ * 環境変数APP_URLで切り替え可能（STG/PRD）
+ * @returns {string} アプリURL
  */
 export function getLiffUrl() {
-  const liffId = process.env.LIFF_ID || '2008227932-Rq9rJrJn';
-  return `https://liff.line.me/${liffId}`;
+  return process.env.APP_URL || 'https://shift-scheduler-ai-liff.vercel.app/';
 }
 
 /**


### PR DESCRIPTION
## Summary
- 締切時刻をDBから取得してメッセージに追記（例: 12月10日 23:59）
- フェーズ指定API `/api/send-reminder-phase` を新設
- フェーズ1~3は手動送信のみに変更（cronではフェーズ4のみ自動送信）
- 通知メッセージのURLをVercel URLに変更（環境変数APP_URLで切替可能）

## 変更ファイル
- `backend/src/services/reminderService.js` - 締切時刻追記、フェーズ指定関数追加、フェーズ1~3スキップ
- `backend/src/services/lineService.js` - URL変更（Vercel URL）
- `backend/src/routes/notification.js` - 締切時刻追記
- `backend/src/index.js` - `/api/send-reminder-phase` エンドポイント追加

## 新しいAPI
```bash
# フェーズを指定してリマインド送信
POST /api/send-reminder-phase
{
  "year": 2026,
  "month": 1,
  "phase": 1  // 1=7日前, 2=3日前, 3=1日前, 4=締切後
}
```

## 環境変数（任意）
- `APP_URL` - 通知メッセージ内のURL（未設定時はPRD用URLがデフォルト）

## Test plan
- [ ] STGで第1案を承認し、メッセージに締切時刻が含まれることを確認
- [ ] STGで `/api/send-reminder-phase` APIを叩いてフェーズ1~3のメッセージが送れることを確認
- [ ] cronが動いてもフェーズ1~3が送信されないことをログで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)