### PR TITLE
feat: アルバイト向け「希望日入力」ボタンを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,6 +221,29 @@
         padding: 8px 10px;
         font-size: 16px;
       }
+      .input-mode-toggle {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 10px;
+      }
+      .toggle-btn {
+        flex: 1;
+        appearance: none;
+        border: 1px solid var(--gray);
+        border-radius: 12px;
+        padding: 10px 12px;
+        font-weight: 700;
+        font-size: 14px;
+        cursor: pointer;
+        background: #fff;
+        color: #333;
+        text-align: center;
+      }
+      .toggle-btn.active {
+        background: var(--green);
+        color: #fff;
+        border-color: var(--green);
+      }
       .footerbar {
         position: sticky;
         bottom: 0;
@@ -371,6 +394,23 @@
           </div>
         </div>
         -->
+
+        <!-- 入力モード切替（アルバイトのみ表示） -->
+        <div id="inputModeToggle" style="margin-top: 10px; display: none">
+          <div class="input-mode-toggle">
+            <button class="toggle-btn active" id="modeTimeBtn">時刻入力</button>
+            <button class="toggle-btn" id="modeAlldayBtn">希望日入力</button>
+          </div>
+        </div>
+
+        <!-- 希望日入力モードのメッセージ -->
+        <div id="alldayBox" style="margin-top: 10px; display: none">
+          <div class="section-title">希望日入力</div>
+          <div class="helper small">
+            希望する日付を選択してください。<br />
+            ※ 05:00〜29:00（終日）で登録されます
+          </div>
+        </div>
 
         <!-- 時刻入力 -->
         <div id="timeBox" style="margin-top: 10px">
@@ -1307,6 +1347,9 @@
         // const patternBox = document.getElementById('patternBox');
         const timeBox = document.getElementById('timeBox');
 
+        const inputModeToggle = document.getElementById('inputModeToggle');
+        const alldayBox = document.getElementById('alldayBox');
+
         if (role === 'part') {
           // アルバイトの場合
           roleInfo.style.background = 'var(--green-weak)';
@@ -1314,8 +1357,13 @@
         <strong style="color:var(--green-strong)">✅ アルバイト</strong><br>
         出勤できる日を<strong class="green">緑</strong>で選択し、時刻を指定してください
       `;
-          // 時刻入力を表示
-          if (timeBox) timeBox.style.display = 'block';
+          // 入力モードトグルを表示
+          if (inputModeToggle) inputModeToggle.style.display = 'block';
+          // 現在のモードに応じて表示切替
+          if (timeBox)
+            timeBox.style.display = mode === 'time' ? 'block' : 'none';
+          if (alldayBox)
+            alldayBox.style.display = mode === 'allday' ? 'block' : 'none';
         } else {
           // 社員の場合：3パターンで分岐
           if (!firstPlanExistsForEmp) {
@@ -1343,8 +1391,10 @@
           <span style="font-size:11px;color:#666">ここでの入力はシフト作成の参考用となります。</span>
         `;
           }
-          // 社員の場合は時刻入力を非表示
+          // 社員の場合は時刻入力・トグルを非表示
           if (timeBox) timeBox.style.display = 'none';
+          if (inputModeToggle) inputModeToggle.style.display = 'none';
+          if (alldayBox) alldayBox.style.display = 'none';
         }
       }
 
@@ -1602,6 +1652,22 @@
         }
       }
 
+      // ====== 入力モード切替（アルバイト用） ======
+      document.getElementById('modeTimeBtn').onclick = () => {
+        mode = 'time';
+        document.getElementById('modeTimeBtn').classList.add('active');
+        document.getElementById('modeAlldayBtn').classList.remove('active');
+        document.getElementById('timeBox').style.display = 'block';
+        document.getElementById('alldayBox').style.display = 'none';
+      };
+      document.getElementById('modeAlldayBtn').onclick = () => {
+        mode = 'allday';
+        document.getElementById('modeAlldayBtn').classList.add('active');
+        document.getElementById('modeTimeBtn').classList.remove('active');
+        document.getElementById('timeBox').style.display = 'none';
+        document.getElementById('alldayBox').style.display = 'block';
+      };
+
       // ====== 月移動 ======
       document.getElementById('prevMonth').onclick = async () => {
         cur.setMonth(cur.getMonth() - 1);
@@ -1819,9 +1885,14 @@
           label.style.display = 'block';
           label.textContent = '出勤不可';
         } else {
-          // アルバイト：パターン/時刻適用
+          // アルバイト：希望日/パターン/時刻適用
           let start, end, tag;
-          if (mode === 'pattern') {
+          if (mode === 'allday') {
+            // 希望日入力：05:00〜29:00（終日）
+            start = '05:00';
+            end = '29:00';
+            tag = '希望日';
+          } else if (mode === 'pattern') {
             start = currentPattern.start;
             end = currentPattern.end;
             tag = currentPattern.key;


### PR DESCRIPTION
## Summary
- アルバイトのシフト入力に「希望日入力」トグルボタンを追加
- 希望日モードで日付を選択すると、05:00〜29:00（終日）が自動セットされ、時刻指定の手間を省略できる
- 送信データは従来通り `start_time` / `end_time` 形式のため、バックエンドの変更は不要

## Changes
- **CSS**: `.input-mode-toggle`, `.toggle-btn` スタイル追加
- **HTML**: 時刻入力の上にトグルボタン（時刻入力 / 希望日入力）を配置
- **JS**: `toggleSelect()` に `allday` モード分岐追加、`updateRoleInfo()` でアルバイトのみ表示制御

## Test plan
- [ ] アルバイトでログインし、「時刻入力」「希望日入力」トグルが表示されること
- [ ] 「希望日入力」タップで時刻セレクトが非表示、説明メッセージが表示されること
- [ ] 希望日モードで日付タップ → セルに「希望日」ラベルが表示されること
- [ ] 「時刻入力」に戻すと通常の時刻指定に戻ること
- [ ] 希望日と時刻指定が混在した状態で送信できること
- [ ] 社員モードではトグルボタンが表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)