### PR TITLE
fix: 希望日モードのカレンダーラベルを時間表示に統一

### DIFF
--- a/index.html
+++ b/index.html
@@ -1891,7 +1891,7 @@
             // 希望日入力：05:00〜29:00（終日）
             start = '05:00';
             end = '29:00';
-            tag = '希望日';
+            tag = `${formatTime(start)}\n-${formatTime(end)}`;
           } else if (mode === 'pattern') {
             start = currentPattern.start;
             end = currentPattern.end;


### PR DESCRIPTION
## Summary
- 希望日入力モードでカレンダーに表示されるラベルを「希望日」テキストから `5:00-29:00` の時間表示に変更
- 通常の時刻入力モードと表示形式を統一

## Test plan
- [ ] 希望日モードで日付をタップ → ラベルが `5:00-29:00` と表示されること
- [ ] 時刻入力モードのラベル表示に影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)